### PR TITLE
Make Target rule name more explicit

### DIFF
--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -26,8 +26,8 @@ module JCR
 
 	rule(:name)      { match('[a-zA-Z]') >> match('[a-zA-Z0-9\-_]').repeat }
     rule(:rule_name) { name.as(:rule_name) }
-	rule(:alias_name) { name.as(:alias_name) }
-	rule(:target_rule_name) { ((alias_name >> str('.')).maybe >> rule_name).as(:target_rule_name) }
+	rule(:namespace_alias) { name.as(:namespace_alias) }
+	rule(:target_rule_name) { ((namespace_alias >> str('.')).maybe >> rule_name).as(:target_rule_name) }
     rule(:integer)   { ( str('-').maybe >> match('[0-9]').repeat ) }
     rule(:p_integer)   { ( match('[0-9]').repeat ) }
     rule(:float)     { str('-').maybe >> match('[0-9]').repeat(1) >> str('.' ) >> match('[0-9]').repeat(1) }
@@ -112,7 +112,7 @@ module JCR
     rule(:language_compatible_members) { str('language-compatible-members').as(:language_compatible_members) }
     rule(:jcr_version_d) { str('jcr-version') >> spaces >> float }
     rule(:ruleset_id_d) { str('ruleset-id') >> spaces >> uri.as(:uri) }
-    rule(:import_d) { str('import') >> spaces >> uri.as(:uri) >> ( spaces >> str('as') >> spaces >> alias_name ).maybe }
+    rule(:import_d) { str('import') >> spaces >> uri.as(:uri) >> ( spaces >> str('as') >> spaces >> namespace_alias ).maybe }
     rule(:directive_def) { pedantic | language_compatible_members | jcr_version_d | ruleset_id_d | import_d }
     rule(:directives) { ( str('#') >> spaces? >> directive_def >> match('[^\r\n]').repeat.maybe >> match('[\r\n]') ).as(:directive) }
     rule(:top) { ( rules | directives ).repeat }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -869,12 +869,14 @@ EX12
   it 'should parse groups of values with namespaced rule names' do
     ex12 = <<EX12
 # import http://ietf.org/rfcXXXX.JCR as rfcXXXX
-rfcXXXX.encodings : ( :"base32" | :"base64" )
+encodings : ( :"base32" | :"base64" )
 more_encodings : ( :"base32hex" | :"base64url" | :"base16" )
 all_encodings ( rfcXXXX.encodings | more_encodings )
 EX12
     tree = JCR.parse( ex12 )
-    expect(tree[1][:rule][:rule_name]).to eq("rfcXXXX.encodings")
+    expect(tree[3][:rule][:rule_name]).to eq("all_encodings")
+    expect(tree[3][:rule][:group_rule][0][:target_rule_name][:alias_name]).to eq("rfcXXXX")
+    expect(tree[3][:rule][:group_rule][0][:target_rule_name][:rule_name]).to eq("encodings")
   end
 
   it 'should parse groups as groups' do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -875,8 +875,21 @@ all_encodings ( rfcXXXX.encodings | more_encodings )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[3][:rule][:rule_name]).to eq("all_encodings")
-    expect(tree[3][:rule][:group_rule][0][:target_rule_name][:alias_name]).to eq("rfcXXXX")
+    expect(tree[3][:rule][:group_rule][0][:target_rule_name][:namespace_alias]).to eq("rfcXXXX")
     expect(tree[3][:rule][:group_rule][0][:target_rule_name][:rule_name]).to eq("encodings")
+  end
+
+  it 'should parse groups of values with non-namespaced rule names' do
+    ex12 = <<EX12
+# import http://ietf.org/rfcXXXX.JCR as rfcXXXX
+encodings : ( :"base32" | :"base64" )
+more_encodings : ( :"base32hex" | :"base64url" | :"base16" )
+all_encodings ( more_encodings | rfcXXXX.encodings )
+EX12
+    tree = JCR.parse( ex12 )
+    expect(tree[3][:rule][:rule_name]).to eq("all_encodings")
+    # expect(tree[3][:rule][:group_rule][0][:target_rule_name][:namespace_alias]).to eq(nil)
+    expect(tree[3][:rule][:group_rule][0][:target_rule_name][:rule_name]).to eq("more_encodings")
   end
 
   it 'should parse groups as groups' do


### PR DESCRIPTION
We may have a different understanding of how the namespacing works, so this may have missed the mark.  But my thinking is that you can set up a namespace alias via an import directive, such as:

#import http://...  as  my_ns_alias

Then refer to a rule in that imported file by doing something like:

my_array [ my_ns_alias.other_rule_name ]

You can still specify a local rule name by doing:

my_other_array [ my_local_rule_name ]

If that's how you intended things hopefully this change makes the grammar more explicit and clearer