### PR TITLE
rules and directives productions define single items

### DIFF
--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -102,7 +102,7 @@ module JCR
       ( spcCmnt? >> comma_or_pipe >> spcCmnt? >> group_def ).repeat >>
       spcCmnt? >> str(')') ).as(:group_rule)
     }
-    rule(:rules) { spcCmnt? >> ( rule_name >> spcCmnt? >>
+    rule(:rule) { spcCmnt? >> ( rule_name >> spcCmnt? >>
       ( value_rule | member_rule | object_rule | array_rule | group_rule ) ).as(:rule) >> spcCmnt?
     }
     rule(:pedantic) { str('pedantic').as(:pedantic) }
@@ -111,8 +111,8 @@ module JCR
     rule(:ruleset_id_d) { str('ruleset-id') >> spaces >> uri.as(:uri) }
     rule(:import_d) { str('import') >> spaces >> uri.as(:uri) >> ( spaces >> str('as') >> spaces >> rule_name ).maybe }
     rule(:directive_def) { pedantic | language_compatible_members | jcr_version_d | ruleset_id_d | import_d }
-    rule(:directives) { ( str('#') >> spaces? >> directive_def >> match('[^\r\n]').repeat.maybe >> match('[\r\n]') ).as(:directive) }
-    rule(:top) { ( rules | directives ).repeat }
+    rule(:directive) { ( str('#') >> spaces? >> directive_def >> match('[^\r\n]').repeat.maybe >> match('[\r\n]') ).as(:directive) }
+    rule(:top) { ( rule | directive ).repeat }
 
     root(:top)
   end


### PR DESCRIPTION
Possibly a bit pedantic, but the rules and directives productions actually defined a single rule or directive.  It seems appropriate to reflect that in their names.