### PR TITLE
Name of combiners should reflect semantics instead of syntax

### DIFF
--- a/lib/jcr/check_groups.rb
+++ b/lib/jcr/check_groups.rb
@@ -48,8 +48,8 @@ module JCR
       node = [ node ]
     end
     node.each do |groupee|
-      if groupee[:comma_o]
-        raise_group_error( 'AND (comma) operation in group rule of value rule', groupee[:comma_o] )
+      if groupee[:sequence_combiner]
+        raise_group_error( 'AND (comma) operation in group rule of value rule', groupee[:sequence_combiner] )
       end
       if groupee[:group_rule]
         disallowed_group_in_value?( groupee[:group_rule], mapping )
@@ -82,8 +82,8 @@ module JCR
       node = [ node ]
     end
     node.each do |groupee|
-      if groupee[:comma_o]
-        raise_group_error( 'AND (comma) operation in group rule of member rule', groupee[:comma_o] )
+      if groupee[:sequence_combiner]
+        raise_group_error( 'AND (comma) operation in group rule of member rule', groupee[:sequence_combiner] )
       end
       if groupee[:group_rule]
         disallowed_group_in_member?( groupee[:group_rule], mapping )

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -68,9 +68,9 @@ module JCR
         ( str('..') >> float.as(:float_max) ) |
         float.as(:float_min) >> str('..')
     }
-    rule(:comma_o)   { str(',').as(:comma_o) }
-    rule(:pipe_o)    { str('|').as(:pipe_o) }
-    rule(:comma_or_pipe) { pipe_o | comma_o }
+    rule(:sequence_combiner)   { str(',').as(:sequence_combiner) }
+    rule(:choice_combiner)    { str('|').as(:choice_combiner) }
+    rule(:sequence_or_choice) { sequence_combiner | choice_combiner }
     rule(:value_def) {
       (
         any | ip4 | ip6 | fqdn | idn | phone | email | base64 | full_time | full_date | date_time |
@@ -87,19 +87,19 @@ module JCR
     }
     rule(:object_def ) { min_max_repetition.maybe >> spcCmnt? >> ( group_rule | member_rule | rule_name.as(:target_rule_name) ) }
     rule(:object_rule) { ( str('{') >> spcCmnt? >>
-      object_def >> ( spcCmnt? >> comma_or_pipe >>
+      object_def >> ( spcCmnt? >> sequence_or_choice >>
       spcCmnt? >> object_def ).repeat  >> spcCmnt? >> str('}')
       ).as(:object_rule)
     }
     rule(:array_def)  { min_max_repetition.maybe >> spcCmnt? >> ( value_rule | group_rule | array_rule | object_rule | rule_name.as(:target_rule_name) ) }
     rule(:array_rule) { ( str('[') >> spcCmnt? >> array_def >>
-      ( spcCmnt? >> comma_or_pipe >> spcCmnt? >> array_def ).repeat >> spcCmnt? >> str(']') ).as(:array_rule)
+      ( spcCmnt? >> sequence_or_choice >> spcCmnt? >> array_def ).repeat >> spcCmnt? >> str(']') ).as(:array_rule)
     }
     rule(:group_def)  { min_max_repetition.maybe >> spcCmnt? >>
       ( group_rule | array_rule | object_rule | value_rule | member_rule | rule_name.as(:target_rule_name) )
     }
     rule(:group_rule) { ( str('(') >> spcCmnt? >> group_def >> spcCmnt? >>
-      ( spcCmnt? >> comma_or_pipe >> spcCmnt? >> group_def ).repeat >>
+      ( spcCmnt? >> sequence_or_choice >> spcCmnt? >> group_def ).repeat >>
       spcCmnt? >> str(')') ).as(:group_rule)
     }
     rule(:rules) { spcCmnt? >> ( rule_name >> spcCmnt? >>


### PR DESCRIPTION
Where possible the grammar productions should reflect their semantic meaning rather than the syntax used to represent them.  So changing comma_o to sequence_combiner (or similar), and pipe_o to choice_combiner (or similar) seems better to me.