### PR TITLE
Fixing integer and integer ranges

### DIFF
--- a/lib/jcr/evaluate_array_rules.rb
+++ b/lib/jcr/evaluate_array_rules.rb
@@ -54,6 +54,20 @@ module JCR
 
       repeat_min = 1
       repeat_max = 1
+      if rule.has_key?(:optional)
+        repeat_min = 0
+        repeat_max = 1
+      end
+      if rule.has_key?(:one_or_more)
+        repeat_min = 1
+        repeat_max = Float::INFINITY
+      end
+      if rule.has_key?(:repetition_min)
+        repeat_min = 0
+      end
+      if rule.has_key?(:repetition_max)
+        repeat_max = Float::INFINITY
+      end
       o = rule[:repetition_min]
       if o
         if o.is_a?( Parslet::Slice )

--- a/lib/jcr/evaluate_object_rules.rb
+++ b/lib/jcr/evaluate_object_rules.rb
@@ -47,6 +47,20 @@ module JCR
 
       repeat_min = 1
       repeat_max = 1
+      if rule.has_key?(:optional)
+        repeat_min = 0
+        repeat_max = 1
+      end
+      if rule.has_key?(:one_or_more)
+        repeat_min = 1
+        repeat_max = Float::INFINITY
+      end
+      if rule.has_key?(:repetition_min)
+        repeat_min = 0
+      end
+      if rule.has_key?(:repetition_max)
+        repeat_max = Float::INFINITY
+      end
       o = rule[:repetition_min]
       if o
         if o.is_a?( Parslet::Slice )

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -29,8 +29,8 @@ module JCR
     rule(:rule_name) { name.as(:rule_name) }
     rule(:namespace_alias) { name.as(:namespace_alias) }
     rule(:target_rule_name) { ((namespace_alias >> str('.')).maybe >> rule_name).as(:target_rule_name) }
-    rule(:integer)   { ( str('-').maybe >> match('[0-9]').repeat ) }
-    rule(:p_integer)   { ( match('[0-9]').repeat ) }
+    rule(:integer)   { ( str('-').maybe >> match('[0-9]').repeat(1) ) }
+    rule(:p_integer)   { ( match('[0-9]').repeat(1) ) }
     rule(:float)     { str('-').maybe >> match('[0-9]').repeat(1) >> str('.' ) >> match('[0-9]').repeat(1) }
     rule(:uri) { match('[a-zA-Z]').repeat(1) >> str(':') >> match('[\S]').repeat(1) }
     rule(:uri_template) { ( match('[a-zA-Z{}]').repeat(1) >> str(':') >> match('[\S]').repeat(1) ).as(:uri_template) }
@@ -63,13 +63,11 @@ module JCR
     rule(:uri_v)     { str('uri').as(:uri) }
     rule(:integer_v) { str('integer').as(:integer_v) }
     rule(:integer_r) {
-      integer.maybe.as(:integer_min) >> str('..') >> integer.maybe.as(:integer_max) | ( str('..') >> integer.as(:integer_max) )
+        integer.as(:integer_min) >> str('..') >> integer.maybe.as(:integer_max) | ( str('..') >> integer.as(:integer_max) )
     }
     rule(:float_v)   { str('float').as(:float_v) }
     rule(:float_r)   {
-        ( float.as(:float_min) >> str('..') >> float.as(:float_max) ) |
-        ( str('..') >> float.as(:float_max) ) |
-        float.as(:float_min) >> str('..')
+        float.as(:float_min) >> str('..') >> float.maybe.as(:float_max) | str('..') >> float.as(:float_max)
     }
 
     rule(:sequence_combiner)   { str(',').as(:sequence_combiner) }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -388,7 +388,7 @@ describe 'parser' do
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
-    expect(tree[0][:rule][:object_rule][1][:repetition_min]).to eq("")
+    expect(tree[0][:rule][:object_rule][1][:repetition_min]).to eq(nil)
     expect(tree[0][:rule][:object_rule][1][:repetition_max]).to eq("1")
   end
 
@@ -404,10 +404,10 @@ describe 'parser' do
     tree = JCR.parse( 'trule { *1my_rule1, *1 my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
-    expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq("")
+    expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq(nil)
     expect(tree[0][:rule][:object_rule][0][:repetition_max]).to eq("1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
-    expect(tree[0][:rule][:object_rule][1][:repetition_min]).to eq("")
+    expect(tree[0][:rule][:object_rule][1][:repetition_min]).to eq(nil)
     expect(tree[0][:rule][:object_rule][1][:repetition_max]).to eq("1")
   end
 
@@ -415,10 +415,10 @@ describe 'parser' do
     tree = JCR.parse( 'trule { *1my_rule1| *1 my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
-    expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq("")
+    expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq(nil)
     expect(tree[0][:rule][:object_rule][0][:repetition_max]).to eq("1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
-    expect(tree[0][:rule][:object_rule][1][:repetition_min]).to eq("")
+    expect(tree[0][:rule][:object_rule][1][:repetition_min]).to eq(nil)
     expect(tree[0][:rule][:object_rule][1][:repetition_max]).to eq("1")
   end
 
@@ -466,7 +466,7 @@ describe 'parser' do
     expect(tree[0][:rule][:array_rule][0][:repetition_max]).to eq("2")
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
     expect(tree[0][:rule][:array_rule][1][:repetition_min]).to eq("1")
-    expect(tree[0][:rule][:array_rule][1][:repetition_max]).to eq("")
+    expect(tree[0][:rule][:array_rule][1][:repetition_max]).to eq(nil)
     expect(tree[0][:rule][:array_rule][2][:target_rule_name][:rule_name]).to eq("my_rule3")
     expect(tree[0][:rule][:array_rule][2][:repetition_max]).to eq("3")
   end
@@ -479,7 +479,7 @@ describe 'parser' do
     expect(tree[0][:rule][:array_rule][0][:repetition_max]).to eq("2")
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
     expect(tree[0][:rule][:array_rule][1][:repetition_min]).to eq("1")
-    expect(tree[0][:rule][:array_rule][1][:repetition_max]).to eq("")
+    expect(tree[0][:rule][:array_rule][1][:repetition_max]).to eq(nil)
     expect(tree[0][:rule][:array_rule][2][:target_rule_name][:rule_name]).to eq("my_rule3")
     expect(tree[0][:rule][:array_rule][2][:repetition_max]).to eq("3")
   end
@@ -492,7 +492,7 @@ describe 'parser' do
     expect(tree[0][:rule][:array_rule][0][:repetition_max]).to eq("2")
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
     expect(tree[0][:rule][:array_rule][1][:repetition_min]).to eq("1")
-    expect(tree[0][:rule][:array_rule][1][:repetition_max]).to eq("")
+    expect(tree[0][:rule][:array_rule][1][:repetition_max]).to eq(nil)
     expect(tree[0][:rule][:array_rule][2][:target_rule_name][:rule_name]).to eq("my_rule3")
     expect(tree[0][:rule][:array_rule][2][:repetition_max]).to eq("3")
   end
@@ -501,8 +501,8 @@ describe 'parser' do
     tree = JCR.parse( 'trule [ * my_rule1, + my_rule2, ? my_rule3, 4 my_rule4 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
-    expect(tree[0][:rule][:array_rule][0][:repetition_min]).to eq("")
-    expect(tree[0][:rule][:array_rule][0][:repetition_max]).to eq("")
+    expect(tree[0][:rule][:array_rule][0][:repetition_min]).to eq(nil)
+    expect(tree[0][:rule][:array_rule][0][:repetition_max]).to eq(nil)
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
     expect(tree[0][:rule][:array_rule][1][:one_or_more]).to eq("+")
     expect(tree[0][:rule][:array_rule][2][:target_rule_name][:rule_name]).to eq("my_rule3")
@@ -514,8 +514,8 @@ describe 'parser' do
   it 'should parse an array rule with rule names ored for one and short repetition' do
     tree = JCR.parse( 'trule [ *my_rule1, +my_rule2| ?my_rule3,4my_rule4 ]' )
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
-    expect(tree[0][:rule][:array_rule][0][:repetition_min]).to eq("")
-    expect(tree[0][:rule][:array_rule][0][:repetition_max]).to eq("")
+    expect(tree[0][:rule][:array_rule][0][:repetition_min]).to eq(nil)
+    expect(tree[0][:rule][:array_rule][0][:repetition_max]).to eq(nil)
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
     expect(tree[0][:rule][:array_rule][1][:one_or_more]).to eq("+")
     expect(tree[0][:rule][:array_rule][2][:target_rule_name][:rule_name]).to eq("my_rule3")


### PR DESCRIPTION
This has a knock on effect to min_max_repetition as previously 'nothing' would match the rule for an integer, so repetition_min would return the empty string rather than nil if there was no integer present.  The logic rationalising the repetitions in evaluate_object_rules.rb etc needs to be changed to reflect this.  I tried to do that but failed!  Thus rspec does generate a few failures, but they are hopefully easy to fix for someone who knows what they're doing!