### PR TITLE
Introduce primitive-rule

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -26,7 +26,7 @@ directive-parameters = not-eol
 not-eol          = HTAB / %x20-10FFFF
 eol              = CR / LF
 
-root-rule        = value-rule / array-rule / object-rule /
+root-rule        = primitive-rule / array-rule / object-rule /
                    member-rule / group-rule
 
 rule             = rule-name *sp-cmt rule-def
@@ -36,8 +36,8 @@ target-rule-name = [ ruleset-id-alias "." ] rule-name
 name             = ALPHA *( ALPHA / DIGIT / "-" / "-" )
 
 rule-def         = type-rule / member-rule / group-rule
-type-rule        = value-rule / array-rule / object-rule /
-                   target-rule-name
+type-rule        = value-rule / target-rule-name
+value-rule       = primitive-rule / array-rule / object-rule
 member-rule      = annotations
                    member-name-spec *sp-cmt (type-rule / type-choice)
 member-name-spec = regex / q-string
@@ -56,15 +56,16 @@ annotation-name  = name
 annotation-parameters = *( spaces / %x21-28 / %x2A-10FFFF )
                    ; Not close bracket - ")"
 
-value-rule       = annotations ":" *sp-cmt ( value-choice / value-def )
-value-choice     = annotations 
-                   "(" *sp-cmt value-choice-items *sp-cmt ")"
-value-choice-items = value-choice-item
-                   *( choice-combiner value-choice-item )
-value-choice-item = ":" *sp-cmt
-                   value-def / value-choice / target-rule-name
+primitive-rule   = annotations ":" *sp-cmt
+                   ( primimitive-choice / primimitive-def )
+primimitive-choice = annotations 
+                   "(" *sp-cmt prim-choice-items *sp-cmt ")"
+prim-choice-items = prim-choice-item
+                   *( choice-combiner prim-choice-item )
+prim-choice-item = ":" *sp-cmt primimitive-def /
+                   primimitive-choice / target-rule-name
 
-value-def        = null-type / boolean-type / true-value / false-value /
+primimitive-def  = null-type / boolean-type / true-value / false-value /
                    string-type / string-range / string-value / 
                    float-type / float-range / float-value /
                    integer-type / integer-range / integer-value / 
@@ -103,13 +104,13 @@ date-time-type   = date-time-kw
 base64-type      = base64-kw
 any              = any-kw
 
-object-rule      = annotations "{" *sp-cmt [ object-items *sp-cmt ] "}"
+object-rule      = annotations [ ":" *sp-cmt ] "{" *sp-cmt [ object-items *sp-cmt ] "}"
 object-items     = object-item *( sequence-or-choice object-item )
 object-item      = [ repetition *sp-cmt ] object-item-types
 object-item-types = member-rule / target-rule-name / object-group
 object-group     = "(" *sp-cmt [ object-items *sp-cmt ] ")"
 
-array-rule       = annotations "[" *sp-cmt [ array-items *sp-cmt ] "]"
+array-rule       = annotations [ ":" *sp-cmt ] "[" *sp-cmt [ array-items *sp-cmt ] "]"
 array-items      = array-item *( sequence-or-choice array-item )
 array-item       = [ repetition ] *sp-cmt array-item-types
 array-item-types = type-rule / array-group
@@ -172,7 +173,7 @@ unescaped        = %x20-21 / %x23-5B / %x5D-10FFFF
 
 regex            = "/" *( escape "/" / not-slash ) "/"
 not-slash        = HTAB / CR / LF / %x20-2E / %x30-10FFFF
-                   ; Any char except ";"
+                   ; Any char except "/"
 uri-template     = 1*ALPHA ":" not-space
 
 ;; Keywords

--- a/lib/jcr/check_groups.rb
+++ b/lib/jcr/check_groups.rb
@@ -25,8 +25,8 @@ module JCR
     else # is a hash
       if tree[:rule]
         check_groups( tree[:rule], mapping )
-      elsif tree[:value_rule]
-        check_value_for_group( tree[:value_rule], mapping )
+      elsif tree[:primitive_rule]
+        check_value_for_group( tree[:primitive_rule], mapping )
       elsif tree[:member_rule]
         check_member_for_group( tree[:member_rule], mapping )
       elsif tree[:array_rule]
@@ -62,8 +62,8 @@ module JCR
         raise_group_error( "groups in value rules cannot have object rules", groupee[:member_rule] )
       elsif groupee[:array_rule]
         raise_group_error( "groups in value rules cannot have array rules", groupee[:member_rule] )
-      elsif groupee[:value_rule]
-        disallowed_group_in_value?( groupee[:value_rule], mapping )
+      elsif groupee[:primitive_rule]
+        disallowed_group_in_value?( groupee[:primitive_rule], mapping )
       end
     end
   end
@@ -172,7 +172,7 @@ module JCR
         raise_group_error( "groups in object rules cannot have array rules", groupee[:member_rule] )
       elsif groupee[:object_rule]
         raise_group_error( "groups in object rules cannot have other object rules", groupee[:member_rule] )
-      elsif groupee[:value_rule]
+      elsif groupee[:primitive_rule]
         raise_group_error( "groups in object rules cannot have value rules", groupee[:member_rule] )
       else
         check_groups( groupee, mapping )

--- a/lib/jcr/evaluate_rules.rb
+++ b/lib/jcr/evaluate_rules.rb
@@ -45,8 +45,8 @@ module JCR
         target = mapping[ jcr[:target_rule_name][:rule_name].to_s ]
         raise "Target rule not in mapping. This should have been checked earlier." unless target
         return evaluate_rule( target, target, data, mapping )
-      when jcr[:value_rule]
-        return evaluate_value_rule( jcr[:value_rule], rule_atom, data, mapping)
+      when jcr[:primitive_rule]
+        return evaluate_value_rule( jcr[:primitive_rule], rule_atom, data, mapping)
       when jcr[:group_rule]
         return evaluate_group_rule( jcr[:group_rule], rule_atom, data, mapping)
       when jcr[:array_rule]
@@ -116,7 +116,7 @@ module JCR
           when sub[:root_annotation]
             annotations << sub
             i = i + 1
-          when sub[:value_rule],sub[:object_rule],sub[:group_rule],sub[:array_rule],sub[:target_rule_name]
+          when sub[:primitive_rule],sub[:object_rule],sub[:group_rule],sub[:array_rule],sub[:target_rule_name]
             break
         end
       end

--- a/lib/jcr/find_roots.rb
+++ b/lib/jcr/find_roots.rb
@@ -95,8 +95,8 @@ module JCR
         retval = rule[:object_rule]
       when rule[:member_rule]
         retval = rule[:member_rule]
-      when rule[:value_rule]
-        retval = rule[:value_rule]
+      when rule[:primitive_rule]
+        retval = rule[:primitive_rule]
       when rule[:group_rule]
         retval = rule[:group_rule]
     end

--- a/lib/jcr/map_rule_names.rb
+++ b/lib/jcr/map_rule_names.rb
@@ -54,8 +54,8 @@ module JCR
           check_rule_target_names( node[:rule], mapping )
         elsif node[:group_rule]
           check_rule_target_names( node[:group_rule], mapping )
-        elsif node[:value_rule]
-          check_rule_target_names( node[:value_rule], mapping )
+        elsif node[:primitive_rule]
+          check_rule_target_names( node[:primitive_rule], mapping )
         elsif node[:array_rule]
           check_rule_target_names( node[:array_rule], mapping )
         elsif node[:object_rule]

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -73,8 +73,8 @@ module JCR
         #! eol = CR / LF
         #!
 
-    rule(:root_rule) { value_rule | array_rule | object_rule | member_rule | group_rule } # N.B. Not target_rule_name
-        #! root_rule = value_rule / array_rule / object_rule /
+    rule(:root_rule) { primitive_rule | array_rule | object_rule | member_rule | group_rule } # N.B. Not target_rule_name
+        #! root_rule = primitive_rule / array_rule / object_rule /
         #!             member_rule / group_rule
         #!
 
@@ -92,9 +92,10 @@ module JCR
 
     rule(:rule_def)          { type_rule | member_rule | group_rule }
         #! rule_def = type_rule / member_rule / group_rule
-    rule(:type_rule)         { value_rule | array_rule | object_rule | target_rule_name }
-        #! type_rule = value_rule / array_rule / object_rule /
-        #!             target_rule_name
+    rule(:type_rule)         { value_rule | target_rule_name }
+        #! type_rule = value_rule / target_rule_name
+    rule(:value_rule)         { primitive_rule | array_rule | object_rule }
+        #! value_rule = primitive_rule / array_rule / object_rule
     rule(:member_rule)       { ( annotations >> member_name_spec >> spcCmnt? >> (type_rule | type_choice) ).as(:member_rule) }
         #! member_rule = annotations
         #!               member_name_spec spcCmnt? (type_rule / type_choice)
@@ -128,20 +129,21 @@ module JCR
         #!                       ; Not close bracket - ")"
         #!
 
-    rule(:value_rule)        { ( annotations >> str(':') >> spcCmnt? >> ( value_choice | value_def ) ).as(:value_rule) }
-        #! value_rule = annotations ":" spcCmnt? ( value_choice / value_def )
-    rule(:value_choice)      { ( annotations >> str('(') >> spcCmnt? >> value_choice_items >> spcCmnt? >> str(')') ).as(:group_rule) }
-        #! value_choice = annotations 
-        #!                "(" spcCmnt? value_choice_items spcCmnt? ")"
-    rule(:value_choice_items) { value_choice_item >> ( spcCmnt? >> choice_combiner >> spcCmnt? >> value_choice_item ).repeat }
-        #! value_choice_items = value_choice_item
-        #!                      *( choice_combiner value_choice_item )
-    rule(:value_choice_item) { ( (str(':') >> spcCmnt? >> value_def) | value_choice | target_rule_name).as(:value_rule) }
-        #! value_choice_item = ":" spcCmnt?
-        #!                     value_def / value_choice / target_rule_name
+    rule(:primitive_rule)        { ( annotations >> str(':') >> spcCmnt? >> ( primimitive_choice | primimitive_def ) ).as(:primitive_rule) }
+        #! primitive_rule = annotations ":" spcCmnt?
+        #!                  ( primimitive_choice / primimitive_def )
+    rule(:primimitive_choice)      { ( annotations >> str('(') >> spcCmnt? >> prim_choice_items >> spcCmnt? >> str(')') ).as(:group_rule) }
+        #! primimitive_choice = annotations 
+        #!                "(" spcCmnt? prim_choice_items spcCmnt? ")"
+    rule(:prim_choice_items) { prim_choice_item >> ( spcCmnt? >> choice_combiner >> spcCmnt? >> prim_choice_item ).repeat }
+        #! prim_choice_items = prim_choice_item
+        #!                      *( choice_combiner prim_choice_item )
+    rule(:prim_choice_item) { ( (str(':') >> spcCmnt? >> primimitive_def) | primimitive_choice | target_rule_name).as(:primitive_rule) }
+        #! prim_choice_item = ":" spcCmnt? primimitive_def /
+        #!                    primimitive_choice / target_rule_name
         #!
 
-    rule(:value_def) {
+    rule(:primimitive_def) {
         null_type | boolean_type | true_value | false_value |
         string_type | string_range | string_value | 
         float_type | float_range | float_value |
@@ -151,7 +153,7 @@ module JCR
         full_date_type | full_time_type | date_time_type |
         base64_type | any
     }
-        #! value_def = null_type / boolean_type / true_value / false_value /
+        #! primimitive_def = null_type / boolean_type / true_value / false_value /
         #!             string_type / string_range / string_value / 
         #!             float_type / float_range / float_value /
         #!             integer_type / integer_range / integer_value / 
@@ -360,8 +362,8 @@ module JCR
 
   class Transformer < Parslet::Transform
 
-    rule(:rule_def=>simple(:value_def)) { puts "found rule definition" }
-    rule(:value_def => simple(:x)) { puts "value sought is " + x }
+    rule(:rule_def=>simple(:primimitive_def)) { puts "found rule definition" }
+    rule(:primimitive_def => simple(:x)) { puts "value sought is " + x }
 
   end
 

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -240,8 +240,9 @@ module JCR
         #> any-kw = "any"
         #!
 
-    rule(:object_rule)  { ( annotations >> str('{') >> spcCmnt? >> object_items.maybe >> spcCmnt? >> str('}') ).as(:object_rule) }
-        #! object_rule = annotations "{" spcCmnt? [ object_items spcCmnt? ] "}"
+    rule(:object_rule)  { ( annotations >> (str(':') >> spcCmnt?).maybe >>
+                        str('{') >> spcCmnt? >> object_items.maybe >> spcCmnt? >> str('}') ).as(:object_rule) }
+        #! object_rule = annotations [ ":" spcCmnt? ] "{" spcCmnt? [ object_items spcCmnt? ] "}"
     rule(:object_items) { object_item >> ( spcCmnt? >> sequence_or_choice >> spcCmnt? >> object_item ).repeat }
         #! object_items = object_item *( sequence_or_choice object_item )
     rule(:object_item ) { repetition.maybe >> spcCmnt? >> object_item_types }
@@ -252,8 +253,9 @@ module JCR
         #! object_group = "(" spcCmnt? [ object_items spcCmnt? ] ")"
         #!
 
-    rule(:array_rule)   { ( annotations >> str('[') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(']') ).as(:array_rule) }
-        #! array_rule = annotations "[" spcCmnt? [ array_items spcCmnt? ] "]"
+    rule(:array_rule)   { ( annotations >> (str(':') >> spcCmnt?).maybe >> 
+                        str('[') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(']') ).as(:array_rule) }
+        #! array_rule = annotations [ ":" spcCmnt? ] "[" spcCmnt? [ array_items spcCmnt? ] "]"
     rule(:array_items)  { array_item >> ( spcCmnt? >> sequence_or_choice >> spcCmnt? >> array_item ).repeat }
         #! array_items = array_item *( sequence_or_choice array_item )
     rule(:array_item)   { repetition.maybe >> spcCmnt? >> array_item_types }

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -349,14 +349,10 @@ module JCR
         #! unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
         #!
 
-    rule(:regex)     {
-      str('/') >>
-        ( str('\\') >> match('[^\r\n]') | str('/').absent? >> match('[^\r\n]') ).repeat.as(:regex) >>
-      str('/')
-    }
+    rule(:regex)     { str('/') >> (str('\\/') | match('[^/]+')).repeat.as(:regex) >> str('/') }
         #! regex = "/" *( escape "/" / not-slash ) "/"
         #! not-slash = HTAB / CR / LF / %x20-2E / %x30-10FFFF
-        #!             ; Any char except ";"
+        #!             ; Any char except "/"
     rule(:uri_template) { ( match('[a-zA-Z{}]').repeat(1) >> str(':') >> match('[\S]').repeat(1) ).as(:uri_template) }
         #! uri_template = 1*ALPHA ":" not-space
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -273,6 +273,12 @@ describe 'parser' do
     expect(tree[0][:rule][:member_rule][:value_rule][:integer_v]).to eq("integer")
   end
 
+  it 'should parse an any member rule of //' do
+    tree = JCR.parse( 'trule // : integer' )
+    expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq([])
+    expect(tree[0][:rule][:member_rule][:value_rule][:integer_v]).to eq("integer")
+  end
+
   it 'should parse an regex member rule with string value' do
     tree = JCR.parse( 'trule /a.regex\\.goes.here.*/ : string' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq("a.regex\\.goes.here.*")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -24,7 +24,7 @@ describe 'parser' do
     begin
       tree = JCR.parse( 'trule : ip4' )
         expect(tree[0][:rule][:rule_name]).to eq("trule")
-        expect(tree[0][:rule][:value_rule][:ip4]).to eq("ip4")
+        expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
       rescue Parslet::ParseFailed => failure
 
         puts failure.cause.ascii_tree
@@ -35,178 +35,178 @@ describe 'parser' do
   it 'should parse an ip4 value defintion 1' do
     tree = JCR.parse( 'trule : ip4' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:value_rule][:ip4]).to eq("ip4")
+    expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
   end
 
   it 'should parse an ip4 value defintion 2' do
     tree = JCR.parse( 'trule :ip4' )
-    expect(tree[0][:rule][:value_rule][:ip4]).to eq("ip4")
+    expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
   end
 
   it 'should parse an ip4 value defintion 3' do
     tree = JCR.parse( 'trule : ip4 ' )
-    expect(tree[0][:rule][:value_rule][:ip4]).to eq("ip4")
+    expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
   end
 
   it 'should parse an ip6 value defintion 1' do
     tree = JCR.parse( 'trule : ip6' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:value_rule][:ip6]).to eq("ip6")
+    expect(tree[0][:rule][:primitive_rule][:ip6]).to eq("ip6")
   end
   it 'should parse an ip6 value defintion 2' do
     tree = JCR.parse( 'trule :ip6' )
-    expect(tree[0][:rule][:value_rule][:ip6]).to eq("ip6")
+    expect(tree[0][:rule][:primitive_rule][:ip6]).to eq("ip6")
   end
   it 'should parse an ip6 value defintion 3' do
     tree = JCR.parse( 'trule : ip6 ' )
-    expect(tree[0][:rule][:value_rule][:ip6]).to eq("ip6")
+    expect(tree[0][:rule][:primitive_rule][:ip6]).to eq("ip6")
   end
 
   it 'should parse a string constant' do
     tree = JCR.parse( 'trule : "a string constant"' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:value_rule][:q_string]).to eq("a string constant")
+    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
   end
 
   it 'should parse a string' do
     tree = JCR.parse( 'trule : string' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:value_rule][:string]).to eq("string")
+    expect(tree[0][:rule][:primitive_rule][:string]).to eq("string")
   end
 
   it 'should parse a regex 1' do
     tree = JCR.parse( 'trule : /a.regex.goes.here.*/' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:value_rule][:regex]).to eq("a.regex.goes.here.*")
+    expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex.goes.here.*")
   end
   it 'should parse a regex 2' do
     tree = JCR.parse( 'trule : /a.regex\\.goes.here.*/' )
-    expect(tree[0][:rule][:value_rule][:regex]).to eq("a.regex\\.goes.here.*")
+    expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex\\.goes.here.*")
   end
 
   it 'should parse a uri' do
     tree = JCR.parse( 'trule : uri' )
-    expect(tree[0][:rule][:value_rule][:uri]).to eq("uri")
+    expect(tree[0][:rule][:primitive_rule][:uri]).to eq("uri")
   end
 
   it 'should parse a uri template' do
     tree = JCR.parse( 'trule : {scheme}://example.com/{path}' )
-    expect(tree[0][:rule][:value_rule][:uri_template]).to eq("{scheme}://example.com/{path}")
+    expect(tree[0][:rule][:primitive_rule][:uri_template]).to eq("{scheme}://example.com/{path}")
   end
 
   it 'should parse a uri template 2' do
     tree = JCR.parse( 'trule : http://example.com/{path}' )
-    expect(tree[0][:rule][:value_rule][:uri_template]).to eq("http://example.com/{path}")
+    expect(tree[0][:rule][:primitive_rule][:uri_template]).to eq("http://example.com/{path}")
   end
 
   it 'should parse an any' do
     tree = JCR.parse( 'trule : any' )
-    expect(tree[0][:rule][:value_rule][:any]).to eq("any")
+    expect(tree[0][:rule][:primitive_rule][:any]).to eq("any")
   end
 
   it 'should parse true' do
     tree = JCR.parse( 'trule : true' )
-    expect(tree[0][:rule][:value_rule][:true_v]).to eq("true")
+    expect(tree[0][:rule][:primitive_rule][:true_v]).to eq("true")
   end
 
   it 'should parse false' do
     tree = JCR.parse( 'trule : false' )
-    expect(tree[0][:rule][:value_rule][:false_v]).to eq("false")
+    expect(tree[0][:rule][:primitive_rule][:false_v]).to eq("false")
   end
 
   it 'should parse boolean' do
     tree = JCR.parse( 'trule : boolean' )
-    expect(tree[0][:rule][:value_rule][:boolean_v]).to eq("boolean")
+    expect(tree[0][:rule][:primitive_rule][:boolean_v]).to eq("boolean")
   end
 
   it 'should parse null' do
     tree = JCR.parse( 'trule : null' )
-    expect(tree[0][:rule][:value_rule][:null]).to eq("null")
+    expect(tree[0][:rule][:primitive_rule][:null]).to eq("null")
   end
 
   it 'should parse a integer value without a range' do
     tree = JCR.parse( 'trule : integer' )
-    expect(tree[0][:rule][:value_rule][:integer_v]).to eq("integer")
+    expect(tree[0][:rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
   it 'should parse a integer constant' do
     tree = JCR.parse( 'trule : 2' )
-    expect(tree[0][:rule][:value_rule][:integer]).to eq("2")
+    expect(tree[0][:rule][:primitive_rule][:integer]).to eq("2")
   end
 
   it 'should parse a negative integer constant' do
     tree = JCR.parse( 'trule : -2' )
-    expect(tree[0][:rule][:value_rule][:integer]).to eq("-2")
+    expect(tree[0][:rule][:primitive_rule][:integer]).to eq("-2")
   end
 
   it 'should parse an integer full range' do
     tree = JCR.parse( 'trule : 0..100' )
-    expect(tree[0][:rule][:value_rule][:integer_min]).to eq("0")
-    expect(tree[0][:rule][:value_rule][:integer_max]).to eq("100")
+    expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
   it 'should parse a negative integer range to positive integer' do
     tree = JCR.parse( 'trule : -1..100' )
-    expect(tree[0][:rule][:value_rule][:integer_min]).to eq("-1")
-    expect(tree[0][:rule][:value_rule][:integer_max]).to eq("100")
+    expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("-1")
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
   it 'should parse a negative integer full range' do
     tree = JCR.parse( 'trule : -100..-1' )
-    expect(tree[0][:rule][:value_rule][:integer_min]).to eq("-100")
-    expect(tree[0][:rule][:value_rule][:integer_max]).to eq("-1")
+    expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("-100")
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-1")
   end
 
   it 'should parse an integer range with a min range' do
     tree = JCR.parse( 'trule : 0..' )
-    expect(tree[0][:rule][:value_rule][:integer_min]).to eq("0")
+    expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
   end
 
   it 'should parse an integer rangge with a max range' do
     tree = JCR.parse( 'trule : ..100' )
-    expect(tree[0][:rule][:value_rule][:integer_max]).to eq("100")
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
   it 'should parse a negative integer range with a max range' do
     tree = JCR.parse( 'trule : ..-100' )
-    expect(tree[0][:rule][:value_rule][:integer_max]).to eq("-100")
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-100")
   end
 
   it 'should parse a float value' do
     tree = JCR.parse( 'trule : float' )
-    expect(tree[0][:rule][:value_rule][:float_v]).to eq("float")
+    expect(tree[0][:rule][:primitive_rule][:float_v]).to eq("float")
   end
 
   it 'should parse a float constant' do
     tree = JCR.parse( 'trule : 2.0' )
-    expect(tree[0][:rule][:value_rule][:float]).to eq("2.0")
+    expect(tree[0][:rule][:primitive_rule][:float]).to eq("2.0")
   end
 
   it 'should parse a negative float constant' do
     tree = JCR.parse( 'trule : -2.0' )
-    expect(tree[0][:rule][:value_rule][:float]).to eq("-2.0")
+    expect(tree[0][:rule][:primitive_rule][:float]).to eq("-2.0")
   end
 
   it 'should parse a float range with a full range' do
     tree = JCR.parse( 'trule : 0.0..100.0' )
-    expect(tree[0][:rule][:value_rule][:float_min]).to eq("0.0")
-    expect(tree[0][:rule][:value_rule][:float_max]).to eq("100.0")
+    expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.0")
+    expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.0")
   end
 
   it 'should parse a negative float range with a full range' do
     tree = JCR.parse( 'trule : -100.0..-1.0' )
-    expect(tree[0][:rule][:value_rule][:float_min]).to eq("-100.0")
-    expect(tree[0][:rule][:value_rule][:float_max]).to eq("-1.0")
+    expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("-100.0")
+    expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("-1.0")
   end
 
   it 'should parse a float range with a min range' do
     tree = JCR.parse( 'trule : 0.3939..' )
-    expect(tree[0][:rule][:value_rule][:float_min]).to eq("0.3939")
+    expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.3939")
   end
 
   it 'should parse a float range with a max range' do
     tree = JCR.parse( 'trule : ..100.003' )
-    expect(tree[0][:rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.003")
   end
 
   it 'should parse an value with group 1' do
@@ -215,34 +215,34 @@ describe 'parser' do
     rescue Parslet::ParseFailed => failure
       puts failure.cause.ascii_tree
     end
-    expect(tree[0][:rule][:value_rule][:group_rule][0][:value_rule][:float]).to eq("1.0")
-    expect(tree[0][:rule][:value_rule][:group_rule][1][:value_rule][:integer]).to eq("2")
-    expect(tree[0][:rule][:value_rule][:group_rule][2][:value_rule][:true_v]).to eq("true")
-    expect(tree[0][:rule][:value_rule][:group_rule][3][:value_rule][:q_string]).to eq("yes")
-    expect(tree[0][:rule][:value_rule][:group_rule][4][:value_rule][:q_string]).to eq("Y")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][0][:primitive_rule][:float]).to eq("1.0")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][1][:primitive_rule][:integer]).to eq("2")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][2][:primitive_rule][:true_v]).to eq("true")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][3][:primitive_rule][:q_string]).to eq("yes")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][4][:primitive_rule][:q_string]).to eq("Y")
   end
 
   it 'should parse a value with group 2' do
     tree = JCR.parse( 'trule : ( :"no" | :false | :1.0 | :2 | :true | :"yes" | :"Y" )' )
-    expect(tree[0][:rule][:value_rule][:group_rule][0][:value_rule][:q_string]).to eq("no")
-    expect(tree[0][:rule][:value_rule][:group_rule][1][:value_rule][:false_v]).to eq("false")
-    expect(tree[0][:rule][:value_rule][:group_rule][2][:value_rule][:float]).to eq("1.0")
-    expect(tree[0][:rule][:value_rule][:group_rule][3][:value_rule][:integer]).to eq("2")
-    expect(tree[0][:rule][:value_rule][:group_rule][4][:value_rule][:true_v]).to eq("true")
-    expect(tree[0][:rule][:value_rule][:group_rule][5][:value_rule][:q_string]).to eq("yes")
-    expect(tree[0][:rule][:value_rule][:group_rule][6][:value_rule][:q_string]).to eq("Y")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][0][:primitive_rule][:q_string]).to eq("no")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][1][:primitive_rule][:false_v]).to eq("false")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][2][:primitive_rule][:float]).to eq("1.0")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][3][:primitive_rule][:integer]).to eq("2")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][4][:primitive_rule][:true_v]).to eq("true")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][5][:primitive_rule][:q_string]).to eq("yes")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][6][:primitive_rule][:q_string]).to eq("Y")
   end
 
   it 'should parse a value with group 3' do
     tree = JCR.parse( 'trule : ( :null | :"no" | :false | :1.0 | :2 | :true | :"yes" | :"Y" )' )
-    expect(tree[0][:rule][:value_rule][:group_rule][0][:value_rule][:null]).to eq("null")
-    expect(tree[0][:rule][:value_rule][:group_rule][1][:value_rule][:q_string]).to eq("no")
-    expect(tree[0][:rule][:value_rule][:group_rule][2][:value_rule][:false_v]).to eq("false")
-    expect(tree[0][:rule][:value_rule][:group_rule][3][:value_rule][:float]).to eq("1.0")
-    expect(tree[0][:rule][:value_rule][:group_rule][4][:value_rule][:integer]).to eq("2")
-    expect(tree[0][:rule][:value_rule][:group_rule][5][:value_rule][:true_v]).to eq("true")
-    expect(tree[0][:rule][:value_rule][:group_rule][6][:value_rule][:q_string]).to eq("yes")
-    expect(tree[0][:rule][:value_rule][:group_rule][7][:value_rule][:q_string]).to eq("Y")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][0][:primitive_rule][:null]).to eq("null")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][1][:primitive_rule][:q_string]).to eq("no")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][2][:primitive_rule][:false_v]).to eq("false")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][3][:primitive_rule][:float]).to eq("1.0")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][4][:primitive_rule][:integer]).to eq("2")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][5][:primitive_rule][:true_v]).to eq("true")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][6][:primitive_rule][:q_string]).to eq("yes")
+    expect(tree[0][:rule][:primitive_rule][:group_rule][7][:primitive_rule][:q_string]).to eq("Y")
   end
 
   it 'should parse two rules' do
@@ -254,13 +254,13 @@ describe 'parser' do
   it 'should parse a member rule with float range with a max range 3' do
     tree = JCR.parse( 'trule "thing" : ..100.003' )
     expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:member_rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
   end
 
   it 'should parse a member rule with integer value' do
     tree = JCR.parse( 'trule "thing" : integer' )
     expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:member_rule][:value_rule][:integer_v]).to eq("integer")
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
   it 'should not parse a repetition member string rule with integer value' do
@@ -270,31 +270,31 @@ describe 'parser' do
   it 'should parse an any member rule with integer value' do
     tree = JCR.parse( 'trule /.*/ : integer' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq(".*")
-    expect(tree[0][:rule][:member_rule][:value_rule][:integer_v]).to eq("integer")
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
   it 'should parse an any member rule of //' do
     tree = JCR.parse( 'trule // : integer' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq([])
-    expect(tree[0][:rule][:member_rule][:value_rule][:integer_v]).to eq("integer")
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
   it 'should parse an regex member rule with string value' do
     tree = JCR.parse( 'trule /a.regex\\.goes.here.*/ : string' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq("a.regex\\.goes.here.*")
-    expect(tree[0][:rule][:member_rule][:value_rule][:string]).to eq("string")
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:string]).to eq("string")
   end
 
   it 'should parse a member rule with an email value 2' do
     tree = JCR.parse( 'trule "thing" : email' )
     expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:member_rule][:value_rule][:email]).to eq("email")
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:email]).to eq("email")
   end
 
   it 'should parse a member rule with integer range with a max range 1' do
     tree = JCR.parse( 'trule "thing" : ..100' )
     expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:member_rule][:value_rule][:integer_max]).to eq("100")
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
   it 'should parse a member rule with a rule name' do
@@ -390,7 +390,7 @@ describe 'parser' do
     tree = JCR.parse( 'trule { "thing" : ..100.003, my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:object_rule][0][:member_rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:object_rule][0][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
@@ -399,7 +399,7 @@ describe 'parser' do
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:object_rule][1][:member_rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:object_rule][1][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
     expect(tree[0][:rule][:object_rule][2][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
@@ -409,7 +409,7 @@ describe 'parser' do
     expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("mem_rule")
     expect(tree[0][:rule][:member_rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:member_rule][:object_rule][1][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:member_rule][:object_rule][1][:member_rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:member_rule][:object_rule][1][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
     expect(tree[0][:rule][:member_rule][:object_rule][2][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
@@ -425,7 +425,7 @@ describe 'parser' do
     tree = JCR.parse( 'trule { "thing" : ..100.003| my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:object_rule][0][:member_rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:object_rule][0][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
@@ -433,7 +433,7 @@ describe 'parser' do
     tree = JCR.parse( 'trule { "thing" : ..100.003, my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
-    expect(tree[0][:rule][:object_rule][0][:member_rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:object_rule][0][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
@@ -506,7 +506,7 @@ describe 'parser' do
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq("0")
     expect(tree[0][:rule][:object_rule][0][:repetition_max]).to eq("1")
-    expect(tree[0][:rule][:object_rule][0][:member_rule][:value_rule][:float_max]).to eq("100.003")
+    expect(tree[0][:rule][:object_rule][0][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -350,6 +350,13 @@ describe 'parser' do
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
+  it 'should parse an object rule with preceding colon' do
+    tree = JCR.parse( 'trule : { my_rule1, my_rule2 }' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
+    expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
+  end
+
   it 'should parse an object rule with rule names or`ed' do
     tree = JCR.parse( 'trule { my_rule1 | my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
@@ -398,6 +405,14 @@ describe 'parser' do
     expect(tree[0][:rule][:member_rule][:object_rule][1][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:member_rule][:object_rule][1][:member_rule][:value_rule][:float_max]).to eq("100.003")
     expect(tree[0][:rule][:member_rule][:object_rule][2][:target_rule_name][:rule_name]).to eq("my_rule2")
+  end
+
+  it 'should parse an object rule with preceding colon' do
+    tree = JCR.parse( 'trule "mem_rule" : { my_rule1, my_rule2 }' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("mem_rule")
+    expect(tree[0][:rule][:member_rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
+    expect(tree[0][:rule][:member_rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an object rule with embeded member rules with value rule ored' do
@@ -503,6 +518,13 @@ describe 'parser' do
 
   it 'should parse an array rule with rule names 1' do
     tree = JCR.parse( 'trule [ my_rule1, my_rule2 ]' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
+    expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
+  end
+
+  it 'should parse an array rule with preceding colon' do
+    tree = JCR.parse( 'trule : [ my_rule1, my_rule2 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")


### PR DESCRIPTION
This also includes allowing : before arrays and objects, and aligning the Parslet definition of a regex with the ABNF definition.