### PR TITLE
Change uri-range syntax to "uri.." uri-template

### DIFF
--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -149,7 +149,7 @@ module JCR
         float_type | float_range | float_value |
         integer_type | integer_range | integer_value | 
         ip4_type | ip6_type | fqdn_type | idn_type |
-        uri_type | uri_range | phone_type | email_type | 
+        uri_range | uri_type | phone_type | email_type |
         full_date_type | full_time_type | date_time_type |
         base64_type | any
     }
@@ -158,7 +158,7 @@ module JCR
         #!             float_type / float_range / float_value /
         #!             integer_type / integer_range / integer_value / 
         #!             ip4_type / ip6_type / fqdn_type / idn_type /
-        #!             uri_type / uri_range / phone_type / email_type / 
+        #!             uri_range / uri_type / phone_type / email_type /
         #!             full_date_type / full_time_type / date_time_type /
         #!             base64_type / any
     rule(:null_type)      { str('null').as(:null) }
@@ -214,11 +214,11 @@ module JCR
     rule(:idn_type)       { str('idn').as(:idn) }
         #! idn_type = idn-kw
         #> idn-kw = "idn"
+    rule(:uri_range)       { str('uri..') >> uri_template }
+        #! uri_range = "uri.." uri_template
+        #> uri-kw = "uri"
     rule(:uri_type)       { str('uri').as(:uri) }
         #! uri_type = uri-kw
-        #> uri-kw = "uri"
-    rule(:uri_range)       { uri_template }
-        #! uri_range = uri_template
     rule(:phone_type)     { str('phone').as(:phone) }
         #! phone_type = phone-kw
         #> phone-kw = "phone"

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -531,7 +531,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should pass a URI template' do
-    tree = JCR.parse( 'trule : http://example.com/{?query*}' )
+    tree = JCR.parse( 'trule : uri..http://example.com/{?query*}' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "http://example.com/?foo=bar", mapping )
@@ -539,7 +539,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should fail a non-matching URI template' do
-    tree = JCR.parse( 'trule : http://example.com/{?query*}' )
+    tree = JCR.parse( 'trule : uri..http://example.com/{?query*}' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "http://example.com", mapping )
@@ -547,7 +547,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should fail a non-string against URI template' do
-    tree = JCR.parse( 'trule : http://example.com/{?query*}' )
+    tree = JCR.parse( 'trule : uri..http://example.com/{?query*}' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {}, mapping )

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -90,12 +90,12 @@ describe 'parser' do
   end
 
   it 'should parse a uri template' do
-    tree = JCR.parse( 'trule : {scheme}://example.com/{path}' )
+    tree = JCR.parse( 'trule : uri..{scheme}://example.com/{path}' )
     expect(tree[0][:rule][:primitive_rule][:uri_template]).to eq("{scheme}://example.com/{path}")
   end
 
   it 'should parse a uri template 2' do
-    tree = JCR.parse( 'trule : http://example.com/{path}' )
+    tree = JCR.parse( 'trule : uri..http://example.com/{path}' )
     expect(tree[0][:rule][:primitive_rule][:uri_template]).to eq("http://example.com/{path}")
   end
 


### PR DESCRIPTION
As mentioned in the issue https://github.com/arineng/jcrvalidator/issues/45 , this adopts a uri-template syntax of:

    rule : uri..http://{etc}

(no intervening spaces)

It's not great, but seems sufficient for parking the issue until a better alternative presents itself.