### PR TITLE
Added annotations to target_rule_name

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -8,7 +8,7 @@ comment-char     = HTAB / %x20-3A / %x3C-10FFFF
                    ; Any char other than ";" / CR / LF
 comment-end-char = CR / LF / ";"
 
-directive        = "#" (one-line-directive / multi-line-directive) *WSP eol
+directive        = "#" (one-line-directive / multi-line-directive)
 one-line-directive = [ spaces ] 
                    (directive-def / one-line-tbd-directive-d) *WSP eol
 multi-line-directive = "{" *sp-cmt
@@ -41,7 +41,7 @@ root-rule        = value-rule / group-rule
 rule             = rule-name *sp-cmt rule-def
 
 rule-name        = name
-target-rule-name = [ ruleset-id-alias "." ] rule-name
+target-rule-name = annotations [ ruleset-id-alias "." ] rule-name
 name             = ALPHA *( ALPHA / DIGIT / "-" / "-" )
 
 rule-def         = type-rule / member-rule / group-rule

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -100,8 +100,8 @@ module JCR
 
     rule(:rule_name)         { name.as(:rule_name) }
         #! rule_name = name
-    rule(:target_rule_name)  { ((ruleset_id_alias >> str('.')).maybe >> rule_name).as(:target_rule_name) }
-        #! target_rule_name  = [ ruleset_id_alias "." ] rule_name
+    rule(:target_rule_name)  { (annotations.as(:annotations) >> (ruleset_id_alias >> str('.')).maybe >> rule_name).as(:target_rule_name) }
+        #! target_rule_name  = annotations [ ruleset_id_alias "." ] rule_name
     rule(:name)              { match('[a-zA-Z]') >> match('[a-zA-Z0-9\-_]').repeat }
         #! name              = ALPHA *( ALPHA / DIGIT / "-" / "_" )
         #!

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -332,8 +332,21 @@ describe 'parser' do
     expect(tree[0][:rule][:member_rule][:target_rule_name][:rule_name]).to eq("my_value_rule")
   end
 
+  it 'should parse a member rule with a rule name with an annotation' do
+    tree = JCR.parse( 'trule "thing" @{id foo } my_value_rule' )
+    expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("thing")
+    expect(tree[0][:rule][:member_rule][:target_rule_name][:rule_name]).to eq("my_value_rule")
+  end
+
   it 'should parse a member rule with a choice rule' do
     tree = JCR.parse( 'trule "thing" : ( an_array | an_object )' )
+    expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("thing")
+    expect(tree[0][:rule][:member_rule][:group_rule][0][:target_rule_name][:rule_name]).to eq("an_array")
+    expect(tree[0][:rule][:member_rule][:group_rule][1][:target_rule_name][:rule_name]).to eq("an_object")
+  end
+
+  it 'should parse a member rule with a choice rule' do
+    tree = JCR.parse( 'trule "thing" : ( @{when $t == "array"} an_array | an_object )' )
     expect(tree[0][:rule][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:member_rule][:group_rule][0][:target_rule_name][:rule_name]).to eq("an_array")
     expect(tree[0][:rule][:member_rule][:group_rule][1][:target_rule_name][:rule_name]).to eq("an_object")
@@ -1303,7 +1316,7 @@ EX12
   end
 
   it 'should parse array rule with reject directive on target rule' do
-    expect{ JCR.parse( 'my_rule [ @{reject} target_rule ]' ) }.to raise_error Parslet::ParseFailed
+    JCR.parse( 'my_rule [ @{reject} target_rule ]' )
   end
 
   it 'should parse a group rule with a rulename only with reject' do


### PR DESCRIPTION
I need to add it as:

    rule(:target_rule_name)  { (annotations.as(:annotations) >> (ruleset_id_alias >> ...

(i.e. add the '.as(:annotations)') to avoid Parslet creating an intermediate array between [:target_rule_name] and [:rule_name] in the output tree.  Hopefully that doesn't cause any problems beyond the slight aesthetic difference.