### PR TITLE
Types renaming

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -15,8 +15,8 @@ multi-line-directive = "{" *sp-cmt
                    (directive-def / multi-line-tbd-directive-d) *sp-cmt "}"
 directive-def    = jcr-version-d / ruleset-id-d / import-d
 jcr-version-d    = jcr-version-kw spaces major-version "." minor-version
-major-version    = p-integer
-minor-version    = p-integer
+major-version    = non-neg-integer
+minor-version    = non-neg-integer
 ruleset-id-d     = ruleset-id-kw spaces ruleset-id
 import-d         = import-kw spaces ruleset-id
                    [ spaces as-kw spaces ruleset-id-alias ]
@@ -38,42 +38,44 @@ not-multi-line-special = spaces / %x21 / %x23-2E / %x30-3A / %x3C-7C /
 
 root-rule        = value-rule / group-rule
 
-rule             = rule-name *sp-cmt "=" *sp-cmt rule-def
+rule             = "$" rule-name *sp-cmt "=" *sp-cmt rule-def
 
 rule-name        = name
-target-rule-name = annotations [ ruleset-id-alias "." ] rule-name
+target-rule-name = annotations "$" [ ruleset-id-alias "." ] rule-name
 name             = ALPHA *( ALPHA / DIGIT / "-" / "-" )
 
-rule-def         = type-rule / member-rule / group-rule
+rule-def         = member-rule / type-rule / group-rule
 type-rule        = value-rule / type-choice-rule / target-rule-name
 value-rule       = primitive-rule / array-rule / object-rule
 member-rule      = annotations
-                   member-name-spec *sp-cmt type-rule
+                   member-name-spec *sp-cmt ":" *sp-cmt type-rule
 member-name-spec = regex / q-string
-type-choice-rule = ":" *sp-cmt type-choice
+type-choice-rule = *sp-cmt type-choice
 type-choice      = annotations "(" type-choice-items
                    *( choice-combiner type-choice-items ) ")"
-type-choice-items = *sp-cmt ( type-choice / type-rule ) *sp-cmt
+type-choice-items = *sp-cmt ( type-choice-rule / type-rule ) *sp-cmt
 
 annotations      = *( "@{" *sp-cmt annotation-set *sp-cmt "}" *sp-cmt )
-annotation-set   = reject-annotation / unordered-annotation /
+annotation-set   = not-annotation / unordered-annotation /
                    root-annotation / tbd-annotation
-reject-annotation = reject-kw
+not-annotation   = not-kw
 unordered-annotation = unordered-kw
 root-annotation  = root-kw
 tbd-annotation   = annotation-name [ spaces annotation-parameters ]
 annotation-name  = name
 annotation-parameters = multi-line-parameters
 
-primitive-rule   = annotations ":" *sp-cmt primimitive-def
-primimitive-def  = null-type / boolean-type / true-value / false-value /
-                   string-type / string-range / string-value / 
-                   float-type / float-range / float-value /
-                   integer-type / integer-range / integer-value / 
-                   ip4-type / ip6-type / fqdn-type / idn-type /
+primitive-rule   = annotations primimitive-def
+primimitive-def  = string-type / string-range / string-value /
+                   null-type / boolean-type / true-value / false-value /
+                   double-type / float-type / float-range / float-value /
+                   integer-type / integer-range / integer-value /
+                   sized-int-type / sized-uint-type /
+                   ipv4-type / ipv6-type / ipaddr-type / fqdn-type / idn-type /
                    uri-range / uri-type / phone-type / email-type /
-                   full-date-type / full-time-type / date-time-type /
-                   base64-type / any
+                   datetime-type / date-type / time-type /
+                   hex-type / base32hex-type / base32-type / base64url-type / base64-type /
+                   any
 null-type        = null-kw
 boolean-type     = boolean-kw
 true-value       = true-kw
@@ -81,6 +83,7 @@ false-value      = false-kw
 string-type      = string-kw
 string-value     = q-string
 string-range     = regex
+double-type      = double-kw
 float-type       = float-kw
 float-range      = float-min ".." [ float-max ] / ".." float-max
 float-min        = float
@@ -91,59 +94,67 @@ integer-range    = integer-min ".." [ integer-max ] / ".." integer-max
 integer-min      = integer
 integer-max      = integer
 integer-value    = integer
-ip4-type         = ip4-kw
-ip6-type         = ip6-kw
+sized-int-type   = int-kw pos-integer
+sized-uint-type  = uint-kw pos-integer
+ipv4-type        = ipv4-kw
+ipv6-type        = ipv6-kw
+ipaddr-type      = ipaddr-kw
 fqdn-type        = fqdn-kw
 idn-type         = idn-kw
 uri-range        = uri-dotdot-kw uri-template
 uri-type         = uri-kw
 phone-type       = phone-kw
 email-type       = email-kw
-full-date-type   = full-date-kw
-full-time-type   = full-time-kw
-date-time-type   = date-time-kw
+datetime-type    = datetime-kw
+date-type        = date-kw
+time-type        = time-kw
+hex-type         = hex-kw
+base32hex-type   = base32hex-kw
+base32-type      = base32-kw
+base64url-type   = base64url-kw
 base64-type      = base64-kw
 any              = any-kw
 
-object-rule      = annotations [ ":" *sp-cmt ] "{" *sp-cmt [ object-items *sp-cmt ] "}"
+object-rule      = annotations "{" *sp-cmt [ object-items *sp-cmt ] "}"
 object-items     = object-item (*( sequence-combiner object-item ) /
                    *( choice-combiner object-item ) )
-object-item      = [ repetition *sp-cmt ] object-item-types
+object-item      = object-item-types [ *sp-cmt repetition ]
 object-item-types = member-rule / target-rule-name / object-group
 object-group     = "(" *sp-cmt [ object-items *sp-cmt ] ")"
 
-array-rule       = annotations [ ":" *sp-cmt ] "[" *sp-cmt [ array-items *sp-cmt ] "]"
+array-rule       = annotations "[" *sp-cmt [ array-items *sp-cmt ] "]"
 array-items      = array-item (*( sequence-combiner array-item ) /
                    *( choice-combiner array-item ) )
-array-item       = [ repetition ] *sp-cmt array-item-types
+array-item       = *sp-cmt array-item-types *sp-cmt [ repetition ]
 array-item-types = type-rule / array-group
 array-group      = "(" *sp-cmt [ array-items *sp-cmt ] ")"
 
 group-rule       = annotations "(" *sp-cmt [ group-items *sp-cmt ] ")"
 group-items      = group-item (*( sequence-combiner group-item ) /
                    *( choice-combiner group-item ) )
-group-item       = [ repetition ] *sp-cmt group-item-types
-group-item-types = type-rule / member-rule / group-group
+group-item       = *sp-cmt group-item-types *sp-cmt [ repetition ]
+group-item-types = member-rule / type-rule / group-group
 group-group      = group-rule
 
 sequence-combiner = *sp-cmt "," *sp-cmt
 choice-combiner  = *sp-cmt "|" *sp-cmt
 
-repetition       = optional / one-or-more / min-max-repetition /
+repetition       = "@" *sp-cmt ( optional / one-or-more / min-max-repetition /
                    min-repetition / max-repetition /
-                   zero-or-more / specific-repetition
+                   zero-or-more / specific-repetition )
 optional         = "?"
 one-or-more      = "+"
 zero-or-more     = "*"
-min-max-repetition = min-repeat *sp-cmt "*" *sp-cmt max-repeat
-min-repetition   = min-repeat *sp-cmt "*"
-max-repetition   = "*" *sp-cmt max-repeat
-min-repeat       = p-integer
-max-repeat       = p-integer
-specific-repetition = p-integer
+min-max-repetition = min-repeat ".." max-repeat
+min-repetition   = min-repeat ".."
+max-repetition   = ".."  max-repeat
+min-repeat       = non-neg-integer
+max-repeat       = non-neg-integer
+specific-repetition = non-neg-integer
 
-integer          = ["-"] 1*DIGIT
-p-integer        = 1*DIGIT
+integer          = "0" / ["-"] pos-integer
+non-neg-integer  = "0" / pos-integer
+pos-integer      = digit1-9 *DIGIT
 
 float            = [ minus ] int frac [ exp ]
                    ; From RFC 7159 except 'frac' required
@@ -184,28 +195,36 @@ uri-template     = 1*ALPHA ":" 1*not-space
 ;; Keywords
 any-kw           = %x61.6E.79                      ; "any"
 as-kw            = %x61.73                         ; "as"
+base32-kw        = %x62.61.73.65.33.32             ; "base32"
+base32hex-kw     = %x62.61.73.65.33.32.68.65.78    ; "base32hex"
 base64-kw        = %x62.61.73.65.36.34             ; "base64"
+base64url-kw     = %x62.61.73.65.36.34.75.72.6C    ; "base64url"
 boolean-kw       = %x62.6F.6F.6C.65.61.6E          ; "boolean"
-date-time-kw     = %x64.61.74.65.2D.74.69.6D.65    ; "date-time"
+date-kw          = %x64.61.74.65                   ; "date"
+datetime-kw      = %x64.61.74.65.74.69.6D.65       ; "datetime"
+double-kw        = %x64.6F.75.62.6C.65             ; "double"
 email-kw         = %x65.6D.61.69.6C                ; "email"
 false-kw         = %x66.61.6C.73.65                ; "false"
 float-kw         = %x66.6C.6F.61.74                ; "float"
 fqdn-kw          = %x66.71.64.6E                   ; "fqdn"
-full-date-kw     = %x66.75.6C.6C.2D.64.61.74.65    ; "full-date"
-full-time-kw     = %x66.75.6C.6C.2D.74.69.6D.65    ; "full-time"
+hex-kw           = %x68.65.78                      ; "hex"
 idn-kw           = %x69.64.6E                      ; "idn"
 import-kw        = %x69.6D.70.6F.72.74             ; "import"
+int-kw           = %x69.6E.74                      ; "int"
 integer-kw       = %x69.6E.74.65.67.65.72          ; "integer"
-ip4-kw           = %x69.70.34                      ; "ip4"
-ip6-kw           = %x69.70.36                      ; "ip6"
+ipaddr-kw        = %x69.70.61.64.64.72             ; "ipaddr"
+ipv4-kw          = %x69.70.76.34                   ; "ipv4"
+ipv6-kw          = %x69.70.76.36                   ; "ipv6"
 jcr-version-kw   = %x6A.63.72.2D.76.65.72.73.69.6F.6E ; "jcr-version"
+not-kw           = %x6E.6F.74                      ; "not"
 null-kw          = %x6E.75.6C.6C                   ; "null"
 phone-kw         = %x70.68.6F.6E.65                ; "phone"
-reject-kw        = %x72.65.6A.65.63.74             ; "reject"
 root-kw          = %x72.6F.6F.74                   ; "root"
 ruleset-id-kw    = %x72.75.6C.65.73.65.74.2D.69.64 ; "ruleset-id"
 string-kw        = %x73.74.72.69.6E.67             ; "string"
+time-kw          = %x74.69.6D.65                   ; "time"
 true-kw          = %x74.72.75.65                   ; "true"
+uint-kw          = %x75.69.6E.74                   ; "uint"
 unordered-kw     = %x75.6E.6F.72.64.65.72.65.64    ; "unordered"
 uri-dotdot-kw    = %x75.72.69.2E.2E                ; "uri.."
 uri-kw           = %x75.72.69                      ; "uri"

--- a/lib/jcr/evaluate_array_rules.rb
+++ b/lib/jcr/evaluate_array_rules.rb
@@ -75,21 +75,21 @@ module JCR
     end
 
     # if the data is not an array
-    return evaluate_reject( annotations,
+    return evaluate_not( annotations,
       Evaluation.new( false, "#{data} is not an array #{raised_rule(jcr,rule_atom)}"), econs ) unless data.is_a? Array
 
     # if the array is zero length and there are zero sub-rules (it is suppose to be empty)
-    return evaluate_reject( annotations,
+    return evaluate_not( annotations,
       Evaluation.new( true, nil ), econs ) if rules.empty? && data.empty?
 
     # if the array is not empty and there are zero sub-rules (it is suppose to be empty)
-    return evaluate_reject( annotations,
+    return evaluate_not( annotations,
       Evaluation.new( false, "Non-empty array for #{raised_rule(jcr,rule_atom)}" ), econs ) if rules.empty? && data.length != 0
 
     if ordered
-      return evaluate_reject( annotations, evaluate_array_rule_ordered( rules, rule_atom, data, econs, behavior ), econs )
+      return evaluate_not( annotations, evaluate_array_rule_ordered( rules, rule_atom, data, econs, behavior ), econs )
     else
-      return evaluate_reject( annotations, evaluate_array_rule_unordered( rules, rule_atom, data, econs, behavior ), econs )
+      return evaluate_not( annotations, evaluate_array_rule_unordered( rules, rule_atom, data, econs, behavior ), econs )
     end
   end
 

--- a/lib/jcr/evaluate_group_rules.rb
+++ b/lib/jcr/evaluate_group_rules.rb
@@ -46,14 +46,14 @@ module JCR
 
     rules.each do |rule|
       if rule[:choice_combiner] && retval && retval.success
-        return evaluate_reject( annotations, retval, econs ) # short circuit
+        return evaluate_not( annotations, retval, econs ) # short circuit
       elsif rule[:sequence_combiner] && retval && !retval.success
-        return evaluate_reject( annotations, retval, econs ) # short circuit
+        return evaluate_not( annotations, retval, econs ) # short circuit
       end
       retval = evaluate_rule( rule, rule_atom, data, econs, behavior )
     end
 
-    return evaluate_reject( annotations, retval, econs )
+    return evaluate_not( annotations, retval, econs )
   end
 
   def self.group_to_s( jcr, shallow=true)

--- a/lib/jcr/evaluate_member_rules.rb
+++ b/lib/jcr/evaluate_member_rules.rb
@@ -63,10 +63,10 @@ module JCR
 
     if member_match
       e = evaluate_rule( rule, rule_atom, data[ 1 ], econs )
-      return evaluate_reject( annotations, e, econs )
+      return evaluate_not( annotations, e, econs )
     end
 
-    return evaluate_reject( annotations,
+    return evaluate_not( annotations,
        Evaluation.new( false, "#{match_spec} does not match #{data[0]} for #{raised_rule( jcr, rule_atom)}" ), econs )
 
   end

--- a/lib/jcr/evaluate_object_rules.rb
+++ b/lib/jcr/evaluate_object_rules.rb
@@ -44,15 +44,15 @@ module JCR
     rules, annotations = get_rules_and_annotations( jcr )
 
     # if the data is not an object (Hash)
-    return evaluate_reject( annotations,
+    return evaluate_not( annotations,
       Evaluation.new( false, "#{data} is not an object for #{raised_rule(jcr,rule_atom)}"), econs ) unless data.is_a? Hash
 
     # if the object has no members and there are zero sub-rules (it is suppose to be empty)
-    return evaluate_reject( annotations,
+    return evaluate_not( annotations,
       Evaluation.new( true, nil ), econs ) if rules.empty? && data.length == 0
 
     # if the object has members and there are zero sub-rules (it is suppose to be empty)
-    return evaluate_reject( annotations,
+    return evaluate_not( annotations,
       Evaluation.new( false, "Non-empty object for #{raised_rule(jcr,rule_atom)}" ), econs ) if rules.empty? && data.length != 0
 
     retval = nil
@@ -64,7 +64,7 @@ module JCR
       if rule[:choice_combiner] && retval && retval.success
         next
       elsif rule[:sequence_combiner] && retval && !retval.success
-        return evaluate_reject( annotations, retval, econs ) # short circuit
+        return evaluate_not( annotations, retval, econs ) # short circuit
       end
 
       repeat_min, repeat_max = get_repetitions( rule, econs )
@@ -150,7 +150,7 @@ module JCR
 
     end # end if grule else
 
-    return evaluate_reject( annotations, retval, econs )
+    return evaluate_not( annotations, retval, econs )
   end
 
   def self.object_to_s( jcr, shallow=true )

--- a/lib/jcr/evaluate_rules.rb
+++ b/lib/jcr/evaluate_rules.rb
@@ -182,7 +182,7 @@ module JCR
           when sub[:unordered_annotation]
             annotations << sub
             i = i + 1
-          when sub[:reject_annotation]
+          when sub[:not_annotation]
             annotations << sub
             i = i + 1
           when sub[:root_annotation]
@@ -198,17 +198,17 @@ module JCR
     return rules, annotations
   end
 
-  def self.evaluate_reject annotations, evaluation, econs
-    reject = false
+  def self.evaluate_not annotations, evaluation, econs
+    is_not = false
     annotations.each do |a|
-      if a[:reject_annotation]
-        reject = true
+      if a[:not_annotation]
+        is_not = true
         break
       end
     end
 
-    if reject
-      trace( econs, "Rejection annotation changing result from #{evaluation.success} to #{!evaluation.success}")
+    if is_not
+      trace( econs, "Not annotation changing result from #{evaluation.success} to #{!evaluation.success}")
       evaluation.success = !evaluation.success
     end
     return evaluation
@@ -380,8 +380,8 @@ module JCR
       case
         when a[:unordered_annotation]
           retval = retval + " @{unordered}"
-        when a[:reject_annotation]
-          retval = retval + " @{reject}"
+        when a[:not_annotation]
+          retval = retval + " @{not}"
         when a[:root_annotation]
           retval = retval + " @{root}"
         else

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -120,7 +120,7 @@ module JCR
       # ip addresses
       #
 
-      when jcr[:ip4]
+      when jcr[:ipv4]
         return bad_value( jcr, rule_atom, "IPv4 Address", data ) unless data.is_a? String
         begin
           ip = IPAddr.new( data )
@@ -128,7 +128,7 @@ module JCR
           return bad_value( jcr, rule_atom, "IPv4 Address", data )
         end
         return bad_value( jcr, rule_atom, "IPv4 Address", data ) unless ip.ipv4?
-      when jcr[:ip6]
+      when jcr[:ipv6]
         return bad_value( jcr, rule_atom, "IPv6 Address", data ) unless data.is_a? String
         begin
           ip = IPAddr.new( data )
@@ -327,10 +327,10 @@ module JCR
       when rule[:regex]
         retval =  "/#{rule[:regex].to_s}/"
 
-      when rule[:ip4]
-        retval =  "ip4"
-      when rule[:ip6]
-        retval =  "ip6"
+      when rule[:ipv4]
+        retval =  "ipv4"
+      when rule[:ipv6]
+        retval =  "ipv6"
 
       when rule[:fqdn]
         retval =  "fqdn"

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -66,6 +66,20 @@ module JCR
         return bad_value( jcr, rule_atom, min, data ) unless data >= min
         max = jcr[:integer_max].to_s.to_i
         return bad_value( jcr, rule_atom, max, data ) unless data <= max
+      when jcr[:sized_int_v]
+        bits = jcr[:sized_int_v][:bits].to_i
+        return bad_value( jcr, rule_atom, "int" + bits.to_s, data ) unless data.is_a?( Fixnum )
+        min = -(2**(bits-1))
+        return bad_value( jcr, rule_atom, min, data ) unless data >= min
+        max = 2**(bits-1)-1
+        return bad_value( jcr, rule_atom, max, data ) unless data <= max
+      when jcr[:sized_uint_v]
+        bits = jcr[:sized_uint_v][:bits].to_i
+        return bad_value( jcr, rule_atom, "int" + bits.to_s, data ) unless data.is_a?( Fixnum )
+        min = 0
+        return bad_value( jcr, rule_atom, min, data ) unless data >= min
+        max = 2**bits-1
+        return bad_value( jcr, rule_atom, max, data ) unless data <= max
 
       #
       # floats
@@ -399,6 +413,10 @@ module JCR
         min = rule[:integer_min].to_s.to_i
         max = rule[:integer_max].to_s.to_i
         retval =  "#{min}..#{max}"
+      when rule[:sized_int_v]
+        retval =  "int" + rule[:sized_int_v][:bits].to_s
+      when rule[:sized_uint_v]
+        retval =  "uint" + rule[:sized_uint_v][:bits].to_s
 
       when rule[:double_v]
         retval =  rule[:double_v].to_s

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -235,14 +235,14 @@ module JCR
       # time and date values
       #
 
-      when jcr[:date_time]
+      when jcr[:datetime]
         return bad_value( jcr, rule_atom, "Time and Date", data ) unless data.is_a? String
         begin
           Time.iso8601( data )
         rescue ArgumentError
           return bad_value( jcr, rule_atom, "Time and Date", data )
         end
-      when jcr[:full_date]
+      when jcr[:date]
         return bad_value( jcr, rule_atom, "Date", data ) unless data.is_a? String
         begin
           d = data + "T23:20:50.52Z"
@@ -250,7 +250,7 @@ module JCR
         rescue ArgumentError
           return bad_value( jcr, rule_atom, "Date", data )
         end
-      when jcr[:full_time]
+      when jcr[:time]
         return bad_value( jcr, rule_atom, "Time", data ) unless data.is_a? String
         begin
           t = "1985-04-12T" + data + "Z"
@@ -351,12 +351,12 @@ module JCR
       when rule[:base64]
         retval =  "base64"
 
-      when rule[:date_time]
-        retval =  "date-time"
-      when rule[:full_date]
-        retval =  "full-date"
-      when rule[:full_time]
-        retval =  "full-time"
+      when rule[:datetime]
+        retval =  "datetime"
+      when rule[:date]
+        retval =  "date"
+      when rule[:time]
+        retval =  "time"
 
       when rule[:null]
         retval =  "null"

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -229,6 +229,51 @@ module JCR
             return bad_value( jcr, rule_atom, "Hex Data", data )
           end
         end
+
+      #
+      # base32hex values
+      #
+
+      when jcr[:base32hex]
+        return bad_value( jcr, rule_atom, "Base32hex Data", data ) unless data.is_a? String
+        return bad_value( jcr, rule_atom, "Base32hex Data", data ) unless data.length % 8 == 0
+        pad_start = false
+        data.each_char do |char|
+          if char == '='
+            pad_start = true
+          elsif pad_start && char != '='
+            return bad_value( jcr, rule_atom, "Base32hex Data", data )
+          else 
+              unless (char >= '0' && char <='9') \
+                  || (char >= 'A' && char <= 'V') \
+                  || (char >= 'a' && char <= 'v')
+                return bad_value( jcr, rule_atom, "Base32hex Data", data )
+              end
+          end
+        end
+
+      #
+      # base32 values
+      #
+
+      when jcr[:base32]
+        return bad_value( jcr, rule_atom, "Base 32 Data", data ) unless data.is_a? String
+        return bad_value( jcr, rule_atom, "Base 32 Data", data ) unless data.length % 8 == 0
+        pad_start = false
+        data.each_char do |char|
+          if char == '='
+            pad_start = true
+          elsif pad_start && char != '='
+            return bad_value( jcr, rule_atom, "Base 32 Data", data )
+          else 
+              unless (char >= 'a' && char <= 'z') \
+                  || (char >= 'A' && char <= 'Z') \
+                  || (char >= '2' && char <='7')
+                return bad_value( jcr, rule_atom, "Base 32 Data", data )
+              end
+          end
+        end
+
       #
       # base64 values
       #
@@ -394,6 +439,8 @@ module JCR
 
       when rule[:hex]
         retval =  "hex"
+      when rule[:base32url]
+        retval =  "base32url"
       when rule[:base64url]
         retval =  "base64url"
       when rule[:base64]

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -85,6 +85,11 @@ module JCR
         return bad_value( jcr, rule_atom, min, data ) unless data >= min
         max = jcr[:float_max].to_s.to_f
         return bad_value( jcr, rule_atom, max, data ) unless data <= max
+      when jcr[:double_v]
+        sf = jcr[:double_v].to_s
+        if sf == "double"
+          return bad_value( jcr, rule_atom, "double", data ) unless data.is_a?( Float )
+        end
 
       #
       # boolean
@@ -303,6 +308,8 @@ module JCR
         max = rule[:integer_max].to_s.to_i
         retval =  "#{min}..#{max}"
 
+      when rule[:double_v]
+        retval =  rule[:double_v].to_s
       when rule[:float_v]
         retval =  rule[:float_v].to_s
       when rule[:float]

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -141,6 +141,14 @@ module JCR
           return bad_value( jcr, rule_atom, "IPv6 Address", data )
         end
         return bad_value( jcr, rule_atom, "IPv6 Address", data ) unless ip.ipv6?
+      when jcr[:ipaddr]
+        return bad_value( jcr, rule_atom, "IP Address", data ) unless data.is_a? String
+        begin
+          ip = IPAddr.new( data )
+        rescue IPAddr::InvalidAddressError
+          return bad_value( jcr, rule_atom, "IP Address", data )
+        end
+        return bad_value( jcr, rule_atom, "IP Address", data ) unless ip.ipv6? || ip.ipv4?
 
       #
       # domain names

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -220,19 +220,41 @@ module JCR
 
       when jcr[:base64]
         return bad_value( jcr, rule_atom, "Base 64 Data", data ) unless data.is_a? String
-        return bad_value( jcr, rule_atom, "Base 64 Data", data ) if data.empty?
         pad_start = false
         data.each_char do |char|
-          if pad_start && char != '='
-            return bad_value( jcr, rule_atom, "Base 64 Data", data )
-          elsif char == '='
+          if char == '='
             pad_start = true
-          end
-          unless (char >= 'a' && char <= 'z') \
-              || (char >= 'A' && char <= 'Z') \
-              || (char >= '0' && char <='9') \
-              || char == '=' || char == '+' || char == '/'
+          elsif pad_start && char != '='
             return bad_value( jcr, rule_atom, "Base 64 Data", data )
+          else 
+              unless (char >= 'a' && char <= 'z') \
+                  || (char >= 'A' && char <= 'Z') \
+                  || (char >= '0' && char <='9') \
+                  || char == '+' || char == '/'
+                return bad_value( jcr, rule_atom, "Base 64 Data", data )
+              end
+          end
+        end
+
+      #
+      # base64url values
+      #
+
+      when jcr[:base64url]
+        return bad_value( jcr, rule_atom, "Base64url Data", data ) unless data.is_a? String
+        pad_start = false
+        data.each_char do |char|
+          if char == '='
+            pad_start = true
+          elsif pad_start && char != '='
+            return bad_value( jcr, rule_atom, "Base64url Data", data )
+          else 
+              unless (char >= 'a' && char <= 'z') \
+                  || (char >= 'A' && char <= 'Z') \
+                  || (char >= '0' && char <='9') \
+                  || char == '-' || char == '_'
+                return bad_value( jcr, rule_atom, "Base64url Data", data )
+              end
           end
         end
 
@@ -357,6 +379,9 @@ module JCR
 
       when rule[:base64]
         retval =  "base64"
+
+      when rule[:base64url]
+        retval =  "base64url"
 
       when rule[:datetime]
         retval =  "datetime"

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -32,7 +32,7 @@ module JCR
     trace_def( econs, "value", jcr, data )
     rules, annotations = get_rules_and_annotations( jcr )
 
-    retval = evaluate_reject( annotations, evaluate_values( rules[0], rule_atom, data, econs ), econs )
+    retval = evaluate_not( annotations, evaluate_values( rules[0], rule_atom, data, econs ), econs )
     trace_eval( econs, "Value", retval)
     pop_trace_stack( econs )
     return retval

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -275,33 +275,12 @@ module JCR
         end
 
       #
-      # base64 values
-      #
-
-      when jcr[:base64]
-        return bad_value( jcr, rule_atom, "Base 64 Data", data ) unless data.is_a? String
-        pad_start = false
-        data.each_char do |char|
-          if char == '='
-            pad_start = true
-          elsif pad_start && char != '='
-            return bad_value( jcr, rule_atom, "Base 64 Data", data )
-          else 
-              unless (char >= 'a' && char <= 'z') \
-                  || (char >= 'A' && char <= 'Z') \
-                  || (char >= '0' && char <='9') \
-                  || char == '+' || char == '/'
-                return bad_value( jcr, rule_atom, "Base 64 Data", data )
-              end
-          end
-        end
-
-      #
       # base64url values
       #
 
       when jcr[:base64url]
         return bad_value( jcr, rule_atom, "Base64url Data", data ) unless data.is_a? String
+        return bad_value( jcr, rule_atom, "Base64url Data", data ) unless data.length % 4 == 0
         pad_start = false
         data.each_char do |char|
           if char == '='
@@ -314,6 +293,29 @@ module JCR
                   || (char >= '0' && char <='9') \
                   || char == '-' || char == '_'
                 return bad_value( jcr, rule_atom, "Base64url Data", data )
+              end
+          end
+        end
+
+      #
+      # base64 values
+      #
+
+      when jcr[:base64]
+        return bad_value( jcr, rule_atom, "Base 64 Data", data ) unless data.is_a? String
+        return bad_value( jcr, rule_atom, "Base 64 Data", data ) unless data.length % 4 == 0
+        pad_start = false
+        data.each_char do |char|
+          if char == '='
+            pad_start = true
+          elsif pad_start && char != '='
+            return bad_value( jcr, rule_atom, "Base 64 Data", data )
+          else 
+              unless (char >= 'a' && char <= 'z') \
+                  || (char >= 'A' && char <= 'Z') \
+                  || (char >= '0' && char <='9') \
+                  || char == '+' || char == '/'
+                return bad_value( jcr, rule_atom, "Base 64 Data", data )
               end
           end
         end

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -215,6 +215,21 @@ module JCR
         return bad_value( jcr, rule_atom, "Phone Number", data ) unless p.valid?
 
       #
+      # hex values
+      #
+
+      when jcr[:hex]
+        return bad_value( jcr, rule_atom, "Hex Data", data ) unless data.is_a? String
+        return bad_value( jcr, rule_atom, "Hex Data", data ) unless data.length % 2 == 0
+        pad_start = false
+        data.each_char do |char|
+          unless (char >= '0' && char <='9') \
+              || (char >= 'A' && char <= 'F') \
+              || (char >= 'a' && char <= 'f')
+            return bad_value( jcr, rule_atom, "Hex Data", data )
+          end
+        end
+      #
       # base64 values
       #
 
@@ -377,11 +392,12 @@ module JCR
       when rule[:phone]
         retval =  "phone"
 
-      when rule[:base64]
-        retval =  "base64"
-
+      when rule[:hex]
+        retval =  "hex"
       when rule[:base64url]
         retval =  "base64url"
+      when rule[:base64]
+        retval =  "base64"
 
       when rule[:datetime]
         retval =  "datetime"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -128,12 +128,12 @@ module JCR
 
     rule(:annotations)       { ( str('@{') >> spcCmnt? >> annotation_set >> spcCmnt? >> str('}') >> spcCmnt? ).repeat }
         #! annotations = *( "@{" spcCmnt? annotation_set spcCmnt? "}" spcCmnt? )
-    rule(:annotation_set)    { reject_annotation | unordered_annotation | root_annotation | tbd_annotation }
-        #! annotation_set = reject_annotation / unordered_annotation /
+    rule(:annotation_set)    { not_annotation | unordered_annotation | root_annotation | tbd_annotation }
+        #! annotation_set = not_annotation / unordered_annotation /
         #!                  root_annotation / tbd_annotation
-    rule(:reject_annotation) { str('reject').as(:reject_annotation) }
-        #! reject_annotation = reject-kw
-        #> reject-kw = "reject"
+    rule(:not_annotation) { str('not').as(:not_annotation) }
+        #! not_annotation = not-kw
+        #> not-kw = "not"
     rule(:unordered_annotation) { str('unordered').as(:unordered_annotation) }
         #! unordered_annotation = unordered-kw
         #> unordered-kw = "unordered"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -153,7 +153,7 @@ module JCR
     rule(:primimitive_def) {
           string_type | string_range | string_value |
           null_type | boolean_type | true_value | false_value |
-          float_type | float_range | float_value |
+          double_type | float_type | float_range | float_value |
           integer_type | integer_range | integer_value |
           ipv4_type | ipv6_type | fqdn_type | idn_type |
           uri_range | uri_type | phone_type | email_type |
@@ -162,7 +162,7 @@ module JCR
     }
         #! primimitive_def = string_type / string_range / string_value /
         #!             null_type / boolean_type / true_value / false_value /
-        #!             float_type / float_range / float_value /
+        #!             double_type / float_type / float_range / float_value /
         #!             integer_type / integer_range / integer_value /
         #!             ipv4_type / ipv6_type / fqdn_type / idn_type /
         #!             uri_range / uri_type / phone_type / email_type /
@@ -187,6 +187,9 @@ module JCR
         #! string_value = q_string
     rule(:string_range)    { regex }
         #! string_range = regex
+    rule(:double_type)     { str('double').as(:double_v) }
+        #! double_type = double-kw
+        #> double-kw = "double"
     rule(:float_type)     { str('float').as(:float_v) }
         #! float_type = float-kw
         #> float-kw = "float"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -155,7 +155,7 @@ module JCR
           null_type | boolean_type | true_value | false_value |
           double_type | float_type | float_range | float_value |
           integer_type | integer_range | integer_value |
-          ipv4_type | ipv6_type | fqdn_type | idn_type |
+          ipv4_type | ipv6_type | ipaddr_type | fqdn_type | idn_type |
           uri_range | uri_type | phone_type | email_type |
           datetime_type | date_type | time_type |
           hex_type | base32hex_type | base32_type | base64url_type | base64_type |
@@ -165,7 +165,7 @@ module JCR
         #!             null_type / boolean_type / true_value / false_value /
         #!             double_type / float_type / float_range / float_value /
         #!             integer_type / integer_range / integer_value /
-        #!             ipv4_type / ipv6_type / fqdn_type / idn_type /
+        #!             ipv4_type / ipv6_type / ipaddr_type / fqdn_type / idn_type /
         #!             uri_range / uri_type / phone_type / email_type /
         #!             datetime_type / date_type / time_type /
         #!             hex_type / base32hex_type / base32_type / base64url_type / base64_type /
@@ -220,6 +220,9 @@ module JCR
     rule(:ipv6_type)       { str('ipv6').as(:ipv6) }
         #! ipv6_type = ipv6-kw
         #> ipv6-kw = "ipv6"
+    rule(:ipaddr_type)       { str('ipaddr').as(:ipaddr) }
+        #! ipaddr_type = ipaddr-kw
+        #> ipaddr-kw = "ipaddr"
     rule(:fqdn_type)      { str('fqdn').as(:fqdn) }
         #! fqdn_type = fqdn-kw
         #> fqdn-kw = "fqdn"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -147,8 +147,8 @@ module JCR
         #! annotation_parameters = multi_line_parameters
         #!
 
-    rule(:primitive_rule)        { ( annotations >> spcCmnt? >> primimitive_def ).as(:primitive_rule) }
-        #! primitive_rule = annotations spcCmnt? primimitive_def
+    rule(:primitive_rule)        { ( annotations >> primimitive_def ).as(:primitive_rule) }
+        #! primitive_rule = annotations primimitive_def
 
     rule(:primimitive_def) {
           string_type | string_range | string_value |
@@ -250,9 +250,9 @@ module JCR
         #> any-kw = "any"
         #!
 
-    rule(:object_rule)  { ( annotations >> spcCmnt?.maybe >>
+    rule(:object_rule)  { ( annotations >>
               str('{') >> spcCmnt? >> object_items.maybe >> spcCmnt? >> str('}') ).as(:object_rule) }
-        #! object_rule = annotations spcCmnt? "{" spcCmnt? [ object_items spcCmnt? ] "}"
+        #! object_rule = annotations "{" spcCmnt? [ object_items spcCmnt? ] "}"
     rule(:object_items) { object_item >> (( spcCmnt? >> sequence_combiner >> spcCmnt? >> object_item ).repeat(1) |
                                           ( spcCmnt? >> choice_combiner >> spcCmnt? >> object_item ).repeat(1) ).maybe }
         #! object_items = object_item (*( sequence_combiner object_item ) /
@@ -265,9 +265,9 @@ module JCR
         #! object_group = "(" spcCmnt? [ object_items spcCmnt? ] ")"
         #!
 
-      rule(:array_rule)   { ( annotations >> spcCmnt?.maybe >>
+      rule(:array_rule)   { ( annotations >>
               str('[') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(']') ).as(:array_rule) }
-        #! array_rule = annotations spcCmnt? "[" spcCmnt? [ array_items spcCmnt? ] "]"
+        #! array_rule = annotations "[" spcCmnt? [ array_items spcCmnt? ] "]"
     rule(:array_items)  { array_item >> (( spcCmnt? >> sequence_combiner >> spcCmnt? >> array_item ).repeat(1) |
                                          ( spcCmnt? >> choice_combiner >> spcCmnt? >> array_item ).repeat(1) ).maybe }
         #! array_items = array_item (*( sequence_combiner array_item ) /

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -158,7 +158,8 @@ module JCR
           ipv4_type | ipv6_type | fqdn_type | idn_type |
           uri_range | uri_type | phone_type | email_type |
           datetime_type | date_type | time_type |
-          base64_type | any
+          base64url_type | base64_type |
+          any
     }
         #! primimitive_def = string_type / string_range / string_value /
         #!             null_type / boolean_type / true_value / false_value /
@@ -167,7 +168,8 @@ module JCR
         #!             ipv4_type / ipv6_type / fqdn_type / idn_type /
         #!             uri_range / uri_type / phone_type / email_type /
         #!             datetime_type / date_type / time_type /
-        #!             base64_type / any
+        #!             base64url_type / base64_type /
+        #!             any
     rule(:null_type)      { str('null').as(:null) }
         #! null_type = null-kw
         #> null-kw = "null"
@@ -248,6 +250,9 @@ module JCR
     rule(:base64_type)    { str('base64').as(:base64) }
         #! base64_type = base64-kw
         #> base64-kw = "base64"
+    rule(:base64url_type)    { str('base64url').as(:base64url) }
+        #! base64url_type = base64url-kw
+        #> base64url-kw = "base64url"
     rule(:any)         { str('any').as(:any) }
         #! any = any-kw
         #> any-kw = "any"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -158,7 +158,7 @@ module JCR
           ipv4_type | ipv6_type | fqdn_type | idn_type |
           uri_range | uri_type | phone_type | email_type |
           datetime_type | date_type | time_type |
-          base64url_type | base64_type |
+          hex_type | base64url_type | base64_type |
           any
     }
         #! primimitive_def = string_type / string_range / string_value /
@@ -168,7 +168,7 @@ module JCR
         #!             ipv4_type / ipv6_type / fqdn_type / idn_type /
         #!             uri_range / uri_type / phone_type / email_type /
         #!             datetime_type / date_type / time_type /
-        #!             base64url_type / base64_type /
+        #!             hex_type / base64url_type / base64_type /
         #!             any
     rule(:null_type)      { str('null').as(:null) }
         #! null_type = null-kw
@@ -247,12 +247,15 @@ module JCR
     rule(:time_type) { str('time').as(:time) }
         #! time_type = time-kw
         #> time-kw = "time"
-    rule(:base64_type)    { str('base64').as(:base64) }
-        #! base64_type = base64-kw
-        #> base64-kw = "base64"
+    rule(:hex_type)    { str('hex').as(:hex) }
+        #! hex_type = hex-kw
+        #> hex-kw = "hex"
     rule(:base64url_type)    { str('base64url').as(:base64url) }
         #! base64url_type = base64url-kw
         #> base64url-kw = "base64url"
+    rule(:base64_type)    { str('base64').as(:base64) }
+        #! base64_type = base64-kw
+        #> base64-kw = "base64"
     rule(:any)         { str('any').as(:any) }
         #! any = any-kw
         #> any-kw = "any"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -155,7 +155,7 @@ module JCR
           null_type | boolean_type | true_value | false_value |
           float_type | float_range | float_value |
           integer_type | integer_range | integer_value |
-          ip4_type | ip6_type | fqdn_type | idn_type |
+          ipv4_type | ipv6_type | fqdn_type | idn_type |
           uri_range | uri_type | phone_type | email_type |
           full_date_type | full_time_type | date_time_type |
           base64_type | any
@@ -164,7 +164,7 @@ module JCR
         #!             null_type / boolean_type / true_value / false_value /
         #!             float_type / float_range / float_value /
         #!             integer_type / integer_range / integer_value /
-        #!             ip4_type / ip6_type / fqdn_type / idn_type /
+        #!             ipv4_type / ipv6_type / fqdn_type / idn_type /
         #!             uri_range / uri_type / phone_type / email_type /
         #!             full_date_type / full_time_type / date_time_type /
         #!             base64_type / any
@@ -209,12 +209,12 @@ module JCR
         #! integer_max = integer
     rule(:integer_value)   { integer.as(:integer) }
         #! integer_value = integer
-    rule(:ip4_type)       { str('ip4').as(:ip4) }
-        #! ip4_type = ip4-kw
-        #> ip4-kw = "ip4"
-    rule(:ip6_type)       { str('ip6').as(:ip6) }
-        #! ip6_type = ip6-kw
-        #> ip6-kw = "ip6"
+    rule(:ipv4_type)       { str('ipv4').as(:ipv4) }
+        #! ipv4_type = ipv4-kw
+        #> ipv4-kw = "ipv4"
+    rule(:ipv6_type)       { str('ipv6').as(:ipv6) }
+        #! ipv6_type = ipv6-kw
+        #> ipv6-kw = "ipv6"
     rule(:fqdn_type)      { str('fqdn').as(:fqdn) }
         #! fqdn_type = fqdn-kw
         #> fqdn-kw = "fqdn"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -157,7 +157,7 @@ module JCR
           integer_type | integer_range | integer_value |
           ipv4_type | ipv6_type | fqdn_type | idn_type |
           uri_range | uri_type | phone_type | email_type |
-          full_date_type | full_time_type | date_time_type |
+          datetime_type | date_type | time_type |
           base64_type | any
     }
         #! primimitive_def = string_type / string_range / string_value /
@@ -166,7 +166,7 @@ module JCR
         #!             integer_type / integer_range / integer_value /
         #!             ipv4_type / ipv6_type / fqdn_type / idn_type /
         #!             uri_range / uri_type / phone_type / email_type /
-        #!             full_date_type / full_time_type / date_time_type /
+        #!             datetime_type / date_type / time_type /
         #!             base64_type / any
     rule(:null_type)      { str('null').as(:null) }
         #! null_type = null-kw
@@ -233,15 +233,15 @@ module JCR
     rule(:email_type)     { str('email').as(:email) }
         #! email_type = email-kw
         #> email-kw = "email"
-    rule(:full_date_type) { str('full-date').as(:full_date) }
-        #! full-date_type = full-date-kw
-        #> full-date-kw = "full-date"
-    rule(:full_time_type) { str('full-time').as(:full_time) }
-        #! full-time_type = full-time-kw
-        #> full-time-kw = "full-time"
-    rule(:date_time_type) { str('date-time').as(:date_time) }
-        #! date-time_type = date-time-kw
-        #> date-time-kw = "date-time"
+    rule(:datetime_type) { str('datetime').as(:datetime) }
+        #! datetime_type = datetime-kw
+        #> datetime-kw = "datetime"
+    rule(:date_type) { str('date').as(:date) }
+        #! date_type = date-kw
+        #> date-kw = "date"
+    rule(:time_type) { str('time').as(:time) }
+        #! time_type = time-kw
+        #> time-kw = "time"
     rule(:base64_type)    { str('base64').as(:base64) }
         #! base64_type = base64-kw
         #> base64-kw = "base64"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -158,7 +158,7 @@ module JCR
           ipv4_type | ipv6_type | fqdn_type | idn_type |
           uri_range | uri_type | phone_type | email_type |
           datetime_type | date_type | time_type |
-          hex_type | base64url_type | base64_type |
+          hex_type | base32hex_type | base32_type | base64url_type | base64_type |
           any
     }
         #! primimitive_def = string_type / string_range / string_value /
@@ -168,7 +168,7 @@ module JCR
         #!             ipv4_type / ipv6_type / fqdn_type / idn_type /
         #!             uri_range / uri_type / phone_type / email_type /
         #!             datetime_type / date_type / time_type /
-        #!             hex_type / base64url_type / base64_type /
+        #!             hex_type / base32hex_type / base32_type / base64url_type / base64_type /
         #!             any
     rule(:null_type)      { str('null').as(:null) }
         #! null_type = null-kw
@@ -250,6 +250,12 @@ module JCR
     rule(:hex_type)    { str('hex').as(:hex) }
         #! hex_type = hex-kw
         #> hex-kw = "hex"
+    rule(:base32hex_type)    { str('base32hex').as(:base32hex) }
+        #! base32hex_type = base32hex-kw
+        #> base32hex-kw = "base32hex"
+    rule(:base32_type)    { str('base32').as(:base32) }
+        #! base32_type = base32-kw
+        #> base32-kw = "base32"
     rule(:base64url_type)    { str('base64url').as(:base64url) }
         #! base64url_type = base64url-kw
         #> base64url-kw = "base64url"

--- a/spec/check_groups_spec.rb
+++ b/spec/check_groups_spec.rb
@@ -37,42 +37,42 @@ describe 'check_groups' do
   end
 
   it 'should be ok with 2 member with group of two OR values' do
-    tree = JCR.parse( '$mrule = "thing" :( integer | float ) ;; $mrule2 = "thing2" :( ip4 | ip6 )' )
+    tree = JCR.parse( '$mrule = "thing" :( integer | float ) ;; $mrule2 = "thing2" :( ipv4 | ipv6 )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with member with group of value OR group' do
-    tree = JCR.parse( '$mrule = "thing" :( integer | ( ip4 | ip6 ) ) ' )
+    tree = JCR.parse( '$mrule = "thing" :( integer | ( ipv4 | ipv6 ) ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with member with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( ip4 | ip6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$grule = ( ipv4 | ipv6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with member with group of value OR rulename with AND' do
-    tree = JCR.parse( '$grule = ( ip4 , ip6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$grule = ( ipv4 , ipv6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with member with group of value OR rulename with AND' do
-    tree = JCR.parse( '$grule = ( "m1" :ip4 | ip6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$grule = ( "m1" :ipv4 | ipv6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should be ok with member with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( ip4 ) ;; $mrule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$grule = ( ipv4 ) ;; $mrule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
@@ -89,35 +89,35 @@ describe 'check_groups' do
   end
 
   it 'should be ok with 2 value with group of two OR values' do
-    tree = JCR.parse( '$rule = ( integer | float ) ;; $rule2 = ( ip4 | ip6 )' )
+    tree = JCR.parse( '$rule = ( integer | float ) ;; $rule2 = ( ipv4 | ipv6 )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with value with group of value OR group' do
-    tree = JCR.parse( '$rule = ( integer | ( ip4 | ip6 ) ) ' )
+    tree = JCR.parse( '$rule = ( integer | ( ipv4 | ipv6 ) ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with value with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( ip4 | ip6 ) ;; $vrule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$grule = ( ipv4 | ipv6 ) ;; $vrule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with value with group of value OR rulename with AND' do
-    tree = JCR.parse( '$grule = ( ip4 , ip6 ) ;; $arule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$grule = ( ipv4 , ipv6 ) ;; $arule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with value with group with member' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ip4 | "thing": $trule ) ;; $arule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 | "thing": $trule ) ;; $arule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
@@ -148,14 +148,14 @@ describe 'check_groups' do
   end
 
   it 'should be ok with array with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( ip4 | ip6 ) ;; $arule = [ ( integer | $grule ) ]' )
+    tree = JCR.parse( '$grule = ( ipv4 | ipv6 ) ;; $arule = [ ( integer | $grule ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with array with group of value OR rulename with member' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ip4 , "thing": $trule ) ;; $arule = [ ( integer | $grule ) ]' )
+    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule = [ ( integer | $grule ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
@@ -186,21 +186,21 @@ describe 'check_groups' do
   end
 
   it 'should be ok with object with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( "m1" :ip4 | "m2" :ip6 ) ;; $arule = { ( "m3" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( "m1" :ipv4 | "m2" :ipv6 ) ;; $arule = { ( "m3" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with object with group of value OR rulename with value' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ip4 , "thing": $trule ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule = { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with member' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ip4 , "thing": $trule ) ;; $arule = { ( "m2" :integer | "m1": $grule ) }' )
+    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule = { ( "m2" :integer | "m1": $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
@@ -214,35 +214,35 @@ describe 'check_groups' do
   end
 
   it 'should be ok with object with group of value OR rulename with value' do
-    tree = JCR.parse( '$grule = ( ip4 ) ;; $orule = { ( "m2" :integer | "m1": $grule ) }' )
+    tree = JCR.parse( '$grule = ( ipv4 ) ;; $orule = { ( "m2" :integer | "m1": $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with object with group of value OR rulename with array' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( [ ip4 ], "thing" :$trule ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$trule = any ;; $grule = ( [ ipv4 ], "thing" :$trule ) ;; $arule = { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with array 2' do
-    tree = JCR.parse( '$grule = ( [ ip4 ] ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( [ ipv4 ] ) ;; $arule = { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with value' do
-    tree = JCR.parse( '$grule = ( ip4 ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( ipv4 ) ;; $arule = { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with object' do
-    tree = JCR.parse( '$grule = ( { "m1" :ip4 } ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( { "m1" :ipv4 } ) ;; $arule = { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError

--- a/spec/evaluate_array_rules_spec.rb
+++ b/spec/evaluate_array_rules_spec.rb
@@ -25,8 +25,8 @@ describe 'evaluate_array_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass something that is not an array with reject' do
-    tree = JCR.parse( '$trule = @{reject} [ ]' )
+  it 'should pass something that is not an array with {not} annotation' do
+    tree = JCR.parse( '$trule = @{not} [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -41,8 +41,8 @@ describe 'evaluate_array_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail an empty reject array against an empty array rule' do
-    tree = JCR.parse( '$trule = @{reject} [ ]' )
+  it 'should fail an empty {not} annotation array against an empty array rule' do
+    tree = JCR.parse( '$trule = @{not} [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [], JCR::EvalConditions.new( mapping, nil ) )
@@ -57,8 +57,8 @@ describe 'evaluate_array_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a non-empty array against an empty reject array rule' do
-    tree = JCR.parse( '$trule = @{reject} [ ]' )
+  it 'should pass a non-empty array against an empty {not} annotation array rule' do
+    tree = JCR.parse( '$trule = @{not} [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -105,8 +105,8 @@ describe 'evaluate_array_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail an array with one string against an reject array rule with a string or a string' do
-    tree = JCR.parse( '$trule = @{reject} [ string | string ]' )
+  it 'should fail an array with one string against an {not} annotation array rule with a string or a string' do
+    tree = JCR.parse( '$trule = @{not} [ string | string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -385,8 +385,8 @@ describe 'evaluate_array_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass an array with one string and one arrays against an reject array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = @{reject} [ string @2, any @2 ]' )
+  it 'should pass an array with one string and one arrays against an {not} annotation array rule with string 2 and any 2' do
+    tree = JCR.parse( '$trule = @{not} [ string @2, any @2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", [ 1, 2 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -441,8 +441,8 @@ describe 'evaluate_array_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail an array with two strings and two arrays against an reject, unordered array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = @{reject} @{unordered} [ string@2, integer@2 ]' )
+  it 'should fail an array with two strings and two arrays against an {not} annotation, unordered array rule with string 2 and any 2' do
+    tree = JCR.parse( '$trule = @{not} @{unordered} [ string@2, integer@2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, "thing", "thing2"  ], JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_group_rules_spec.rb
+++ b/spec/evaluate_group_rules_spec.rb
@@ -25,8 +25,8 @@ describe 'evaluate_group_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a group with string variable with reject' do
-    tree = JCR.parse( '$trule = @{reject} ( string )' )
+  it 'should fail a group with string variable with {not} annotation' do
+    tree = JCR.parse( '$trule = @{not} ( string )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -57,8 +57,8 @@ describe 'evaluate_group_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a group with an ipv4 or an integer with reject' do
-    tree = JCR.parse( '$trule = @{reject} ( ipv4 | integer )' )
+  it 'should pass a group with an ipv4 or an integer with {not} annotation' do
+    tree = JCR.parse( '$trule = @{not} ( ipv4 | integer )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_group_rules_spec.rb
+++ b/spec/evaluate_group_rules_spec.rb
@@ -49,16 +49,16 @@ describe 'evaluate_group_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a group with an ip4 or an integer' do
-    tree = JCR.parse( '$trule = ( ip4 | integer )' )
+  it 'should fail a group with an ipv4 or an integer' do
+    tree = JCR.parse( '$trule = ( ipv4 | integer )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a group with an ip4 or an integer with reject' do
-    tree = JCR.parse( '$trule = @{reject} ( ip4 | integer )' )
+  it 'should pass a group with an ipv4 or an integer with reject' do
+    tree = JCR.parse( '$trule = @{reject} ( ipv4 | integer )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_member_rules_spec.rb
+++ b/spec/evaluate_member_rules_spec.rb
@@ -29,8 +29,8 @@ describe 'evaluate_member_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a member with string and any value with reject' do
-    tree = JCR.parse( '$mrule = @{reject} "mname" :any' )
+  it 'should fail a member with string and any value with {not} annotation' do
+    tree = JCR.parse( '$mrule = @{not} "mname" :any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "mname", "anything" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -53,8 +53,8 @@ describe 'evaluate_member_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a member with mismatch string and an integer with reject' do
-    tree = JCR.parse( '$mrule = @{reject} "mname" :integer' )
+  it 'should pass a member with mismatch string and an integer with {not} annotation' do
+    tree = JCR.parse( '$mrule = @{not} "mname" :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -89,8 +89,8 @@ describe 'evaluate_member_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a member with regex and any value with reject' do
-    tree = JCR.parse( '$mrule = @{reject} /ab.*/ :any' )
+  it 'should fail a member with regex and any value with {not} annotation' do
+    tree = JCR.parse( '$mrule = @{not} /ab.*/ :any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", "anything" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -113,8 +113,8 @@ describe 'evaluate_member_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a member with mismatch regex and an integer with reject' do
-    tree = JCR.parse( '$mrule = @{reject} /ab.*/ :integer' )
+  it 'should pass a member with mismatch regex and an integer with {not} annotation' do
+    tree = JCR.parse( '$mrule = @{not} /ab.*/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_object_rules_spec.rb
+++ b/spec/evaluate_object_rules_spec.rb
@@ -25,8 +25,8 @@ describe 'evaluate_object_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass something that is not an object with reject' do
-    tree = JCR.parse( '$trule= @{reject} { }' )
+  it 'should pass something that is not an object with {not} annotation' do
+    tree = JCR.parse( '$trule= @{not} { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -41,8 +41,8 @@ describe 'evaluate_object_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail an empty object against an empty reject object rule' do
-    tree = JCR.parse( '$trule= @{reject} { }' )
+  it 'should fail an empty object against an empty {not} annotation object rule' do
+    tree = JCR.parse( '$trule= @{not} { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { }, JCR::EvalConditions.new( mapping, nil ) )
@@ -57,8 +57,8 @@ describe 'evaluate_object_rules' do
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a non-empty object against an empty reject object rule' do
-    tree = JCR.parse( '$trule= @{reject} { }' )
+  it 'should pass a non-empty object against an empty {not} annotation object rule' do
+    tree = JCR.parse( '$trule= @{not} { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"bar"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -105,8 +105,8 @@ describe 'evaluate_object_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail an object with one string against an reject object rule with a string member or a string member' do
-    tree = JCR.parse( '$trule= @{reject} { "foo":string | "bar":string }' )
+  it 'should fail an object with one string against an {not} annotation object rule with a string member or a string member' do
+    tree = JCR.parse( '$trule= @{not} { "foo":string | "bar":string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -362,15 +362,15 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should not ignore extra members in an object' do
-    tree = JCR.parse( '$trule= { /s.*/:string@2, "foo":integer@1, @{reject} /.*/:any@+ }' )
+    tree = JCR.parse( '$trule= { /s.*/:string@2, "foo":integer@1, @{not} /.*/:any@+ }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2,"bar"=>"baz" }, JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass object with not extra members using reject' do
-    tree = JCR.parse( '$trule= { /s.*/:string@2, "foo":integer@1, @{reject} /.*/:any @? }' )
+  it 'should pass object with not extra members using {not} annotation' do
+    tree = JCR.parse( '$trule= { /s.*/:string@2, "foo":integer@1, @{not} /.*/:any @? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2 }, JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -191,10 +191,26 @@ describe 'evaluate_value_rules' do
   end
 
   #
-  # float value tests
+  # float / double value tests
   #
 
-  it 'should pass an float variable' do
+  it 'should pass a double variable' do
+    tree = JCR.parse( '$trule= double' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 2.1, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a double variable when passed a string' do
+    tree = JCR.parse( '$trule= double' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a float variable' do
     tree = JCR.parse( '$trule= float' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -202,7 +218,7 @@ describe 'evaluate_value_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail an float variable when passed a string' do
+  it 'should fail a float variable when passed a string' do
     tree = JCR.parse( '$trule= float' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -387,7 +387,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass an IPv4 address that matches' do
-    tree = JCR.parse( '$trule= ip4' )
+    tree = JCR.parse( '$trule= ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -395,7 +395,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv4 address that does not match' do
-    tree = JCR.parse( '$trule= ip4' )
+    tree = JCR.parse( '$trule= ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -403,7 +403,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv4 address that is not a string' do
-    tree = JCR.parse( '$trule= ip4' )
+    tree = JCR.parse( '$trule= ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -411,7 +411,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv4 address that is suppose to be an IPv6 address' do
-    tree = JCR.parse( '$trule= ip6' )
+    tree = JCR.parse( '$trule= ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -419,7 +419,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an IPv6 address that matches' do
-    tree = JCR.parse( '$trule= ip6' )
+    tree = JCR.parse( '$trule= ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1", JCR::EvalConditions.new( mapping, nil ) )
@@ -427,7 +427,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a fully expanded IPv6 address that matches' do
-    tree = JCR.parse( '$trule= ip6' )
+    tree = JCR.parse( '$trule= ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000:0000:0000:0000:0000:0000:0001", JCR::EvalConditions.new( mapping, nil ) )
@@ -435,7 +435,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv6 address that does not match' do
-    tree = JCR.parse( '$trule= ip6' )
+    tree = JCR.parse( '$trule= ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1....", JCR::EvalConditions.new( mapping, nil ) )
@@ -443,7 +443,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv6 address that is not a string' do
-    tree = JCR.parse( '$trule= ip6' )
+    tree = JCR.parse( '$trule= ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [], JCR::EvalConditions.new( mapping, nil ) )
@@ -451,7 +451,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv6 address that is suppose to be an IPv4 address' do
-    tree = JCR.parse( '$trule= ip4' )
+    tree = JCR.parse( '$trule= ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1", JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -474,6 +474,46 @@ describe 'evaluate_value_rules' do
     expect( e.success ).to be_falsey
   end
 
+  it 'should pass an ipaddr that matches an IPv4 address' do
+    tree = JCR.parse( '$trule= ipaddr' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass an ipaddr that matches an IPv6 address' do
+    tree = JCR.parse( '$trule= ipaddr' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail an ipaddr address that is not a string' do
+    tree = JCR.parse( '$trule= ipaddr' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], [], JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail an ipaddr address that does not match' do
+    tree = JCR.parse( '$trule= ipaddr' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail an ipaddr that does not match' do
+    tree = JCR.parse( '$trule= ipaddr' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1....", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
   #
   # domain value tests
   #

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -719,6 +719,94 @@ describe 'evaluate_value_rules' do
   end
 
   #
+  # Base32hex data type
+  #
+
+  it 'should pass a base32hex string' do
+    tree = JCR.parse( '$trule= base32hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFV3", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a empty base32hex string' do
+    tree = JCR.parse( '$trule= base32hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a number that is not a base32hex string' do
+    tree = JCR.parse( '$trule= base32hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a string with illegal base32hex characters' do
+    tree = JCR.parse( '$trule= base32hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFCZ", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a base32hex string if length is not multiple of 8' do
+    tree = JCR.parse( '$trule= base32hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "ABCD", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  #
+  # Base32 data type
+  #
+
+  it 'should pass a base32 string' do
+    tree = JCR.parse( '$trule= base32' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFZ3", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a empty base32 string' do
+    tree = JCR.parse( '$trule= base32' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a number that is not a base32 string' do
+    tree = JCR.parse( '$trule= base32' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a string with illegal base32 characters' do
+    tree = JCR.parse( '$trule= base32' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFZ1", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a base32 string if length is not multiple of 8' do
+    tree = JCR.parse( '$trule= base32' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "ABCD", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  #
   # Base64 data type
   #
 

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -190,6 +190,174 @@ describe 'evaluate_value_rules' do
     expect( e.success ).to be_falsey
   end
 
+  it 'should pass a sized integer within a range' do
+    tree = JCR.parse( '$trule= int8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 100, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a negative sized integer within a range' do
+    tree = JCR.parse( '$trule= int8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], -100, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a sized integer below a range' do
+    tree = JCR.parse( '$trule= int8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], -129, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a sized integer above a range' do
+    tree = JCR.parse( '$trule= int8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 128, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a sized integer at the min of a range' do
+    tree = JCR.parse( '$trule= int8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], -128, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a sized integer at the max of a range' do
+    tree = JCR.parse( '$trule= int8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 127, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a sized integer below a range' do
+    tree = JCR.parse( '$trule= int16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], -32769, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a sized integer above a range' do
+    tree = JCR.parse( '$trule= int16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 32768, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a sized integer at the min of a range' do
+    tree = JCR.parse( '$trule= int16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], -32768, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a sized integer at the max of a range' do
+    tree = JCR.parse( '$trule= int16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 32767, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a sized integer range when passed a string' do
+    tree = JCR.parse( '$trule= int8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a sized unsigned integer within a range' do
+    tree = JCR.parse( '$trule= uint8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 100, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a sized unsigned integer below a range' do
+    tree = JCR.parse( '$trule= uint8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], -1, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a sized unsigned integer above a range' do
+    tree = JCR.parse( '$trule= uint8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 256, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a sized unsigned integer at the min of a range' do
+    tree = JCR.parse( '$trule= uint8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 0, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a sized unsigned integer at the max of a range' do
+    tree = JCR.parse( '$trule= uint8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 255, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a sized unsigned integer below a range' do
+    tree = JCR.parse( '$trule= uint16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], -1, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a sized unsigned integer above a range' do
+    tree = JCR.parse( '$trule= uint16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 65536, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a sized unsigned integer at the min of a range' do
+    tree = JCR.parse( '$trule= uint16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 0, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a sized unsigned integer at the max of a range' do
+    tree = JCR.parse( '$trule= uint16' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 65535, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a sized unsigned integer range when passed a string' do
+    tree = JCR.parse( '$trule= uint8' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
   #
   # float / double value tests
   #

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -682,7 +682,7 @@ describe 'evaluate_value_rules' do
     tree = JCR.parse( '$trule= base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
-    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==", JCR::EvalConditions.new( mapping, nil ) )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVz+/==", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_truthy
   end
 
@@ -712,6 +712,50 @@ describe 'evaluate_value_rules' do
 
   it 'should fail a string with base64 characters after padding' do
     tree = JCR.parse( '$trule= base64' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaa", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  #
+  # Base64url data type
+  #
+
+  it 'should pass a base64url string' do
+    tree = JCR.parse( '$trule= base64url' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVz-_==", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a empty base64url string' do
+    tree = JCR.parse( '$trule= base64url' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a number that is not a base64url string' do
+    tree = JCR.parse( '$trule= base64url' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a string with illegal base64url characters' do
+    tree = JCR.parse( '$trule= base64url' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA%==", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a string with base64url characters after padding' do
+    tree = JCR.parse( '$trule= base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaa", JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -675,6 +675,50 @@ describe 'evaluate_value_rules' do
   end
 
   #
+  # Hex data type
+  #
+
+  it 'should pass a hex string' do
+    tree = JCR.parse( '$trule= hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "1234AB", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should pass a empty hex string' do
+    tree = JCR.parse( '$trule= hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a number that is not a hex string' do
+    tree = JCR.parse( '$trule= hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a string with illegal hex characters' do
+    tree = JCR.parse( '$trule= hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "1234GH", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a hex string that does not have even length' do
+    tree = JCR.parse( '$trule= hex' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "12345", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  #
   # Base64 data type
   #
 

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -838,7 +838,7 @@ describe 'evaluate_value_rules' do
     tree = JCR.parse( '$trule= base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
-    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA%==", JCR::EvalConditions.new( mapping, nil ) )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzA%==", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
@@ -846,7 +846,7 @@ describe 'evaluate_value_rules' do
     tree = JCR.parse( '$trule= base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
-    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaa", JCR::EvalConditions.new( mapping, nil ) )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaaa", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
@@ -882,7 +882,7 @@ describe 'evaluate_value_rules' do
     tree = JCR.parse( '$trule= base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
-    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA%==", JCR::EvalConditions.new( mapping, nil ) )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzA%==", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
@@ -890,7 +890,7 @@ describe 'evaluate_value_rules' do
     tree = JCR.parse( '$trule= base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
-    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaa", JCR::EvalConditions.new( mapping, nil ) )
+    e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaaa", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -698,80 +698,80 @@ describe 'evaluate_value_rules' do
   # Date and Time value tests
   #
 
-  it 'should pass a date-time string' do
-    tree = JCR.parse( '$trule= date-time' )
+  it 'should pass a datetime string' do
+    tree = JCR.parse( '$trule= datetime' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-04-12T23:20:50.52Z", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a number being passed as date-time' do
-    tree = JCR.parse( '$trule= date-time' )
+  it 'should fail a number being passed as datetime' do
+    tree = JCR.parse( '$trule= datetime' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should fail a badly formatted date-time' do
-    tree = JCR.parse( '$trule= date-time' )
+  it 'should fail a badly formatted datetime' do
+    tree = JCR.parse( '$trule= datetime' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-04-12T23.20.50.52Z", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a full-date string' do
-    tree = JCR.parse( '$trule= full-date' )
+  it 'should pass a date string' do
+    tree = JCR.parse( '$trule= date' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-04-12", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a number being passed as full-date' do
-    tree = JCR.parse( '$trule= full-date' )
+  it 'should fail a number being passed as date' do
+    tree = JCR.parse( '$trule= date' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should fail a badly formatted full-date' do
-    tree = JCR.parse( '$trule= full-date' )
+  it 'should fail a badly formatted date' do
+    tree = JCR.parse( '$trule= date' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-14-12", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass a full-time string' do
-    tree = JCR.parse( '$trule= full-time' )
+  it 'should pass a time string' do
+    tree = JCR.parse( '$trule= time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "23:20:50.52", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a number being passed as full-time' do
-    tree = JCR.parse( '$trule= full-time' )
+  it 'should fail a number being passed as time' do
+    tree = JCR.parse( '$trule= time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should fail a badly formatted full-time with Z' do
-    tree = JCR.parse( '$trule= full-time' )
+  it 'should fail a badly formatted time with Z' do
+    tree = JCR.parse( '$trule= time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "23.20.50.52Z", JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
   end
 
-  it 'should fail a badly formatted full-time with bad-data' do
-    tree = JCR.parse( '$trule= full-time' )
+  it 'should fail a badly formatted time with bad-data' do
+    tree = JCR.parse( '$trule= time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "24.20.50.52", JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -686,6 +686,14 @@ describe 'evaluate_value_rules' do
     expect( e.success ).to be_truthy
   end
 
+  it 'should pass a empty base64 string' do
+    tree = JCR.parse( '$trule= base64' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
   it 'should fail a number that is not a base64 string' do
     tree = JCR.parse( '$trule= base64' )
     mapping = JCR.map_rule_names( tree )

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -46,8 +46,8 @@ describe 'evaluate_value_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail when any rule matches an array with reject' do
-    tree = JCR.parse( '$trule= @{reject} any' )
+  it 'should fail when any rule matches an array with {not} annotation' do
+    tree = JCR.parse( '$trule= @{not} any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -66,8 +66,8 @@ describe 'evaluate_value_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail when a string matches a string constant with reject' do
-    tree = JCR.parse( '$trule= @{reject} "a string constant"' )
+  it 'should fail when a string matches a string constant with {not} annotation' do
+    tree = JCR.parse( '$trule= @{not} "a string constant"' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -346,8 +346,8 @@ describe 'evaluate_value_rules' do
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail a null with reject' do
-    tree = JCR.parse( '$trule= @{reject} null' )
+  it 'should fail a null with {not} annotation' do
+    tree = JCR.parse( '$trule= @{not} null' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], nil, JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/jcr_spec.rb
+++ b/spec/jcr_spec.rb
@@ -19,7 +19,7 @@ require_relative '../lib/jcr/jcr'
 
 describe 'jcr' do
 
-  it 'should pass defualt rule' do
+  it 'should pass default rule' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.5
@@ -32,7 +32,7 @@ EX
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail defualt rule' do
+  it 'should fail default rule' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.5
@@ -45,7 +45,7 @@ EX
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass defualt rule referencing another rule' do
+  it 'should pass default rule referencing another rule' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.5
@@ -59,7 +59,7 @@ EX
     expect( e.success ).to be_truthy
   end
 
-  it 'should pass defualt rule referencing two rules with JSON' do
+  it 'should pass default rule referencing two rules with JSON' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.5
@@ -131,7 +131,7 @@ EX
     expect( e.success ).to be_falsey
   end
 
-  it 'should pass defualt rule referencing two rules with JSON and override' do
+  it 'should pass default rule referencing two rules with JSON and override' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.5
@@ -151,7 +151,7 @@ OV
     expect( e.success ).to be_truthy
   end
 
-  it 'should fail defualt rule referencing two rules with JSON and override!' do
+  it 'should fail default rule referencing two rules with JSON and override!' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.5
@@ -171,7 +171,7 @@ OV
     expect( e.success ).to be_falsey
   end
 
-  it 'should fail defualt rule referencing two rules with JSON and override!' do
+  it 'should fail default rule referencing two rules with JSON and override!' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.5

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -213,6 +213,11 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-100")
   end
 
+  it 'should parse a double value' do
+    tree = JCR.parse( '$trule = double' )
+    expect(tree[0][:rule][:primitive_rule][:double_v]).to eq("double")
+  end
+
   it 'should parse a float value' do
     tree = JCR.parse( '$trule = float' )
     expect(tree[0][:rule][:primitive_rule][:float_v]).to eq("float")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -62,6 +62,12 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:ipv6]).to eq("ipv6")
   end
 
+  it 'should parse an ipaddr value' do
+    tree = JCR.parse( '$trule = ipaddr' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:primitive_rule][:ipaddr]).to eq("ipaddr")
+  end
+
   it 'should parse a string constant' do
     tree = JCR.parse( '$trule = "a string constant"' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1255,24 +1255,24 @@ EX12
     expect{ JCR.parse( '$my_int = ..' ) }.to raise_error Parslet::ParseFailed
   end
 
-  it 'should parse value rule with reject directive' do
-    tree = JCR.parse( '$my_int = @{reject} 2' )
+  it 'should parse value rule with {not} annotation directive' do
+    tree = JCR.parse( '$my_int = @{not} 2' )
   end
 
-  it 'should parse member rule with reject directive' do
-    tree = JCR.parse( '$my_mem = @{reject} "count" :integer' )
+  it 'should parse member rule with {not} annotation directive' do
+    tree = JCR.parse( '$my_mem = @{not} "count" :integer' )
   end
 
-  it 'should parse object rule with reject directive' do
-    tree = JCR.parse( '$my_rule = @{reject} { "count" :integer }' )
+  it 'should parse object rule with {not} annotation directive' do
+    tree = JCR.parse( '$my_rule = @{not} { "count" :integer }' )
   end
 
-  it 'should parse object rule with reject directive' do
-    tree = JCR.parse( '$my_rule = @{root} @{reject} { "count" :integer }' )
+  it 'should parse object rule with {not} annotation directive' do
+    tree = JCR.parse( '$my_rule = @{root} @{not} { "count" :integer }' )
   end
 
-  it 'should parse array rule with reject directive' do
-    tree = JCR.parse( '$my_rule = @{reject} [ integer@* ]' )
+  it 'should parse array rule with {not} annotation directive' do
+    tree = JCR.parse( '$my_rule = @{not} [ integer@* ]' )
   end
 
   it 'should parse array rule with unordered directive' do
@@ -1284,27 +1284,27 @@ EX12
   end
 
   it 'should parse array rule with unordered directive' do
-    tree = JCR.parse( '$my_rule = @{unordered} @{reject} [ integer@* ]' )
+    tree = JCR.parse( '$my_rule = @{unordered} @{not} [ integer@* ]' )
   end
 
   it 'should parse array rule with unordered directive' do
-    tree = JCR.parse( '$my_rule = @{reject} @{unordered} [ integer@* ]' )
+    tree = JCR.parse( '$my_rule = @{not} @{unordered} [ integer@* ]' )
   end
 
-  it 'should parse group rule with reject directive' do
-    tree = JCR.parse( '$my_rule = @{ reject } ( integer@* )' )
+  it 'should parse group rule with {not} annotation directive' do
+    tree = JCR.parse( '$my_rule = @{ not } ( integer@* )' )
   end
 
-  it 'should parse array rule with reject directive on value rule' do
-    tree = JCR.parse( '$my_rule = [ @{reject} integer @* ]' )
+  it 'should parse array rule with {not} annotation directive on value rule' do
+    tree = JCR.parse( '$my_rule = [ @{not} integer @* ]' )
   end
 
-  it 'should parse array rule with reject directive on target rule' do
-    JCR.parse( '$my_rule = [ @{reject} $target_rule ]' )
+  it 'should parse array rule with {not} annotation directive on target rule' do
+    JCR.parse( '$my_rule = [ @{not} $target_rule ]' )
   end
 
-  it 'should parse a group rule with a rulename only with reject' do
-    tree = JCR.parse( '$trule = @{reject} ( $my_rule1 )' )
+  it 'should parse a group rule with a rulename only with {not} annotation' do
+    tree = JCR.parse( '$trule = @{not} ( $my_rule1 )' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -20,11 +20,11 @@ describe 'parser' do
 =begin
   an example of printing out the ascii_tree
 
-  it 'should parse an ip4 value defintion 1' do
+  it 'should parse an ipv4 value defintion 1' do
     begin
-      tree = JCR.parse( '$trule = ip4' )
+      tree = JCR.parse( '$trule = ipv4' )
         expect(tree[0][:rule][:rule_name]).to eq("trule")
-        expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
+        expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
       rescue Parslet::ParseFailed => failure
 
         puts failure.cause.ascii_tree
@@ -32,34 +32,34 @@ describe 'parser' do
   end
 =end
 
-  it 'should parse an ip4 value defintion 1' do
-    tree = JCR.parse( '$trule = ip4' )
+  it 'should parse an ipv4 value defintion 1' do
+    tree = JCR.parse( '$trule = ipv4' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
+    expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
   end
 
-  it 'should parse an ip4 value defintion 2' do
-    tree = JCR.parse( '$trule = ip4' )
-    expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
+  it 'should parse an ipv4 value defintion 2' do
+    tree = JCR.parse( '$trule = ipv4' )
+    expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
   end
 
-  it 'should parse an ip4 value defintion 3' do
-    tree = JCR.parse( '$trule = ip4 ' )
-    expect(tree[0][:rule][:primitive_rule][:ip4]).to eq("ip4")
+  it 'should parse an ipv4 value defintion 3' do
+    tree = JCR.parse( '$trule = ipv4 ' )
+    expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
   end
 
-  it 'should parse an ip6 value defintion 1' do
-    tree = JCR.parse( '$trule = ip6' )
+  it 'should parse an ipv6 value defintion 1' do
+    tree = JCR.parse( '$trule = ipv6' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:primitive_rule][:ip6]).to eq("ip6")
+    expect(tree[0][:rule][:primitive_rule][:ipv6]).to eq("ipv6")
   end
-  it 'should parse an ip6 value defintion 2' do
-    tree = JCR.parse( '$trule = ip6' )
-    expect(tree[0][:rule][:primitive_rule][:ip6]).to eq("ip6")
+  it 'should parse an ipv6 value defintion 2' do
+    tree = JCR.parse( '$trule = ipv6' )
+    expect(tree[0][:rule][:primitive_rule][:ipv6]).to eq("ipv6")
   end
-  it 'should parse an ip6 value defintion 3' do
-    tree = JCR.parse( '$trule = ip6 ' )
-    expect(tree[0][:rule][:primitive_rule][:ip6]).to eq("ip6")
+  it 'should parse an ipv6 value defintion 3' do
+    tree = JCR.parse( '$trule = ipv6 ' )
+    expect(tree[0][:rule][:primitive_rule][:ipv6]).to eq("ipv6")
   end
 
   it 'should parse a string constant' do
@@ -1060,7 +1060,7 @@ $nameserver = {
      "name" : fqdn,
 
      ; the ip addresses of the nameserver
-     "ipAddresses" : [ ( ip4 | ip6 )@* ],
+     "ipAddresses" : [ ( ipv4 | ipv6 )@* ],
 
      ; common rules for all structures
      $common
@@ -1173,7 +1173,7 @@ EX12
 
   it 'should parse groups as groups' do
     ex12 = <<EX12
-$encodings = ( "base32" | "base64" | integer | /^.{5,10}/ | ip4 | ip6 | fqdn )
+$encodings = ( "base32" | "base64" | integer | /^.{5,10}/ | ipv4 | ipv6 | fqdn )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[0][:rule][:rule_name]).to eq("encodings")
@@ -1188,11 +1188,11 @@ EX12
   end
 
   it 'should error with 1 member with group of OR values and member with group of AND values' do
-    expect{ JCR.parse( '$mrule = "thing" : ( integer | float ) ;; $mrule2 = "thing2" : ( ip4 , ip6 )' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$mrule = "thing" : ( integer | float ) ;; $mrule2 = "thing2" : ( ipv4 , ipv6 )' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with member with group of value OR group' do
-    expect{ JCR.parse( '$mrule = "thing" : ( integer | ( ip4 , ip6 ) ) ' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$mrule = "thing" : ( integer | ( ipv4 , ipv6 ) ) ' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with object with group of value OR value' do
@@ -1224,11 +1224,11 @@ EX12
   end
 
   it 'should error with array with group of value OR with group with member' do
-    expect{ JCR.parse( '$trule = any ;; $rule = [ ( integer | ( ip4 | "thing" : $trule ) ) ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = any ;; $rule = [ ( integer | ( ipv4 | "thing" : $trule ) ) ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with array with group of OR values and array with group of values and member' do
-    expect{ JCR.parse( '$trule = any ;; $rule = [ ( integer | float ) ] ;; $rule2 = [ ( ip4 , "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = any ;; $rule = [ ( integer | float ) ] ;; $rule2 = [ ( ipv4 , "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with array with value and group of one value and one member' do
@@ -1244,7 +1244,7 @@ EX12
   end
 
   it 'should error with value with group of value OR group with member' do
-    expect{ JCR.parse( '$trule = :any ;; $rule = ( integer | ( ip4 | "thing" : $trule ) ) ' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :any ;; $rule = ( integer | ( ipv4 | "thing" : $trule ) ) ' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with value with group of ORed and ANDED values' do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -219,6 +219,16 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-100")
   end
 
+  it 'should parse a sized int value without a range' do
+    tree = JCR.parse( '$trule = int32' )
+    expect(tree[0][:rule][:primitive_rule][:sized_int_v][:bits]).to eq("32")
+  end
+
+  it 'should parse a sized int value without a range' do
+    tree = JCR.parse( '$trule = uint32' )
+    expect(tree[0][:rule][:primitive_rule][:sized_uint_v][:bits]).to eq("32")
+  end
+
   it 'should parse a double value' do
     tree = JCR.parse( '$trule = double' )
     expect(tree[0][:rule][:primitive_rule][:double_v]).to eq("double")


### PR DESCRIPTION
This does:

- @{reject} to @{not}
- intXX and uintXX
- double
- full-date to date
- full-time to time
- date-time to datetime
- base64url, plus hex, base32 and base32hex
- ip4 -> ipv4, ip6 -> ipv6, ipaddr

I've called base16 'hex' because that seems a more common name for that sort of thing.  I can easily change that if desired.
