### PR TITLE
Type designator

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -68,8 +68,8 @@ tbd-annotation   = annotation-name [ spaces annotation-parameters ]
 annotation-name  = name
 annotation-parameters = multi-line-parameters
 
-primitive-rule   = annotations primimitive-def
-primimitive-def  = string-type / string-range / string-value /
+primitive-rule   = annotations primitive-def
+primitive-def    = string-type / string-range / string-value /
                    null-type / boolean-type / true-value / false-value /
                    double-type / float-type / float-range / float-value /
                    integer-type / integer-range / integer-value /

--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -44,12 +44,15 @@ rule-name        = name
 target-rule-name = annotations "$" [ ruleset-id-alias "." ] rule-name
 name             = ALPHA *( ALPHA / DIGIT / "-" / "-" )
 
-rule-def         = member-rule / type-rule / group-rule
-type-rule        = value-rule / type-choice-rule / target-rule-name
+rule-def         = member-rule / type-designator rule-def-type-rule /
+                   array-rule / object-rule / group-rule / target-rule-name
+type-designator  = "type" 1*sp-cmt / ":" *sp-cmt
+rule-def-type-rule = value-rule / type-choice-rule
 value-rule       = primitive-rule / array-rule / object-rule
 member-rule      = annotations
                    member-name-spec *sp-cmt ":" *sp-cmt type-rule
 member-name-spec = regex / q-string
+type-rule        = value-rule / type-choice-rule / target-rule-name
 type-choice-rule = *sp-cmt type-choice
 type-choice      = annotations "(" type-choice-items
                    *( choice-combiner type-choice-items ) ")"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -106,10 +106,14 @@ module JCR
         #! name              = ALPHA *( ALPHA / DIGIT / "-" / "_" )
         #!
 
-    rule(:rule_def)          { member_rule | type_rule | group_rule }
-        #! rule_def = member_rule / type_rule / group_rule
-    rule(:type_rule)         { value_rule | type_choice_rule | target_rule_name }
-        #! type_rule = value_rule / type_choice_rule / target_rule_name
+    rule(:rule_def)          { member_rule | (type_designator >> rule_def_type_rule) | 
+                               array_rule | object_rule | group_rule | target_rule_name }
+        #! rule_def = member_rule / type_designator rule_def_type_rule /
+        #!            array_rule / object_rule / group_rule / target_rule_name
+    rule(:type_designator)   { str('type') >> spcCmnt.repeat(1) | str(':') >> spcCmnt? }
+        #! type_designator = "type" 1*spcCmnt / ":" spcCmnt?
+    rule(:rule_def_type_rule)     { value_rule | type_choice_rule }
+        #! rule_def_type_rule = value_rule / type_choice_rule
     rule(:value_rule)         { primitive_rule | array_rule | object_rule }
         #! value_rule = primitive_rule / array_rule / object_rule
     rule(:member_rule)       { ( annotations >> member_name_spec >> spcCmnt? >> str(':') >> spcCmnt? >> type_rule ).as(:member_rule) }
@@ -117,6 +121,8 @@ module JCR
         #!               member_name_spec spcCmnt? ":" spcCmnt? type_rule
     rule(:member_name_spec)  { regex.as(:member_regex) | q_string.as(:member_name) }
         #! member_name_spec = regex / q_string
+    rule(:type_rule)         { value_rule | type_choice_rule | target_rule_name }
+        #! type_rule = value_rule / type_choice_rule / target_rule_name
     rule(:type_choice_rule)  { spcCmnt? >> type_choice }
         #! type_choice_rule = spcCmnt? type_choice
     rule(:type_choice)       { ( annotations >> str('(') >> type_choice_items >> ( choice_combiner >> type_choice_items ).repeat >> str(')') ).as(:group_rule) }

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -153,10 +153,10 @@ module JCR
         #! annotation_parameters = multi_line_parameters
         #!
 
-    rule(:primitive_rule)        { ( annotations >> primimitive_def ).as(:primitive_rule) }
-        #! primitive_rule = annotations primimitive_def
+    rule(:primitive_rule)        { ( annotations >> primitive_def ).as(:primitive_rule) }
+        #! primitive_rule = annotations primitive_def
 
-    rule(:primimitive_def) {
+    rule(:primitive_def) {
           string_type | string_range | string_value |
           null_type | boolean_type | true_value | false_value |
           double_type | float_type | float_range | float_value |
@@ -168,7 +168,7 @@ module JCR
           hex_type | base32hex_type | base32_type | base64url_type | base64_type |
           any
     }
-        #! primimitive_def = string_type / string_range / string_value /
+        #! primitive_def = string_type / string_range / string_value /
         #!             null_type / boolean_type / true_value / false_value /
         #!             double_type / float_type / float_range / float_value /
         #!             integer_type / integer_range / integer_value /
@@ -416,8 +416,8 @@ module JCR
 
   class Transformer < Parslet::Transform
 
-    rule(:rule_def=>simple(:primimitive_def)) { puts "found rule definition" }
-    rule(:primimitive_def => simple(:x)) { puts "value sought is " + x }
+    rule(:rule_def=>simple(:primitive_def)) { puts "found rule definition" }
+    rule(:primitive_def => simple(:x)) { puts "value sought is " + x }
 
   end
 

--- a/spec/check_groups_spec.rb
+++ b/spec/check_groups_spec.rb
@@ -51,7 +51,7 @@ describe 'check_groups' do
   end
 
   it 'should be ok with member with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( ipv4 | ipv6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$grule =: ( ipv4 | ipv6 ) ;; $mrule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
@@ -82,21 +82,21 @@ describe 'check_groups' do
   # value rule tests
   #
   it 'should be ok with value with group of two OR values' do
-    tree = JCR.parse( '$rule = ( integer | float ) ' )
+    tree = JCR.parse( '$rule =: ( integer | float ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with 2 value with group of two OR values' do
-    tree = JCR.parse( '$rule = ( integer | float ) ;; $rule2 = ( ipv4 | ipv6 )' )
+    tree = JCR.parse( '$rule =: ( integer | float ) ;; $rule2 = ( ipv4 | ipv6 )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with value with group of value OR group' do
-    tree = JCR.parse( '$rule = ( integer | ( ipv4 | ipv6 ) ) ' )
+    tree = JCR.parse( '$rule =: ( integer | ( ipv4 | ipv6 ) ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
@@ -117,7 +117,7 @@ describe 'check_groups' do
   end
 
   it 'should error with value with group with member' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 | "thing": $trule ) ;; $arule = "thing" :( integer | $grule ) ' )
+    tree = JCR.parse( '$trule =: any ;; $grule = ( ipv4 | "thing": $trule ) ;; $arule = "thing" :( integer | $grule ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
@@ -127,35 +127,35 @@ describe 'check_groups' do
   # array rule tests
   #
   it 'should be not barf on an empty array while checking for groups' do
-    tree = JCR.parse( '$rule = [ ]' )
+    tree = JCR.parse( '$rule =: [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with array with group of two OR values' do
-    tree = JCR.parse( '$rule = [ ( integer | float ) ]' )
+    tree = JCR.parse( '$rule =: [ ( integer | float ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with array with two groups of two OR values' do
-    tree = JCR.parse( '$rule = [ ( integer | float ), ( string, string ) ]' )
+    tree = JCR.parse( '$rule =: [ ( integer | float ), ( string, string ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with array with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( ipv4 | ipv6 ) ;; $arule = [ ( integer | $grule ) ]' )
+    tree = JCR.parse( '$grule =: ( ipv4 | ipv6 ) ;; $arule =: [ ( integer | $grule ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with array with group of value OR rulename with member' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule = [ ( integer | $grule ) ]' )
+    tree = JCR.parse( '$trule =: any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule =: [ ( integer | $grule ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
@@ -165,84 +165,84 @@ describe 'check_groups' do
   # object rule tests
   #
   it 'should not barf on an empty object' do
-    tree = JCR.parse( '$rule = { }' )
+    tree = JCR.parse( '$rule =: { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with object with group of two OR values' do
-    tree = JCR.parse( '$rule = { ( "thing" :integer | "thing2" :integer ) }' )
+    tree = JCR.parse( '$rule =: { ( "thing" :integer | "thing2" :integer ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with object with two groups of two OR members' do
-    tree = JCR.parse( '$rule = { ( "m1" :integer | "m2" :float ), ( "m3" :string, "m4" :string ) }' )
+    tree = JCR.parse( '$rule =: { ( "m1" :integer | "m2" :float ), ( "m3" :string, "m4" :string ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should be ok with object with group of value OR rulename' do
-    tree = JCR.parse( '$grule = ( "m1" :ipv4 | "m2" :ipv6 ) ;; $arule = { ( "m3" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( "m1" :ipv4 | "m2" :ipv6 ) ;; $arule =: { ( "m3" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with object with group of value OR rulename with value' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$trule =: any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule =: { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with member' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule = { ( "m2" :integer | "m1": $grule ) }' )
+    tree = JCR.parse( '$trule =: any ;; $grule = ( ipv4 , "thing": $trule ) ;; $arule =: { ( "m2" :integer | "m1": $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with member 2' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( "thing": $trule ) ;; $arule = { ( "m2" :integer | "m1": $grule ) }' )
+    tree = JCR.parse( '$trule =: any ;; $grule = ( "thing": $trule ) ;; $arule =: { ( "m2" :integer | "m1": $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should be ok with object with group of value OR rulename with value' do
-    tree = JCR.parse( '$grule = ( ipv4 ) ;; $orule = { ( "m2" :integer | "m1": $grule ) }' )
+    tree = JCR.parse( '$grule =: ( ipv4 ) ;; $orule =: { ( "m2" :integer | "m1": $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     JCR.check_groups( tree, mapping )
   end
 
   it 'should error with object with group of value OR rulename with array' do
-    tree = JCR.parse( '$trule = any ;; $grule = ( [ ipv4 ], "thing" :$trule ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$trule =: any ;; $grule = ( [ ipv4 ], "thing" :$trule ) ;; $arule =: { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with array 2' do
-    tree = JCR.parse( '$grule = ( [ ipv4 ] ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( [ ipv4 ] ) ;; $arule =: { ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with value' do
-    tree = JCR.parse( '$grule = ( ipv4 ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( ipv4 ) ;; $arule = :{ ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should error with object with group of value OR rulename with object' do
-    tree = JCR.parse( '$grule = ( { "m1" :ipv4 } ) ;; $arule = { ( "m2" :integer | $grule ) }' )
+    tree = JCR.parse( '$grule = ( { "m1" :ipv4 } ) ;; $arule = :{ ( "m2" :integer | $grule ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect{ JCR.check_groups( tree, mapping ) }.to raise_error RuntimeError

--- a/spec/evaluate_array_rules_spec.rb
+++ b/spec/evaluate_array_rules_spec.rb
@@ -18,7 +18,7 @@ require_relative '../lib/jcr/evaluate_array_rules'
 describe 'evaluate_array_rules' do
 
   it 'should fail something that is not an array' do
-    tree = JCR.parse( '$trule = [ ]' )
+    tree = JCR.parse( '$trule =: [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -26,7 +26,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass something that is not an array with {not} annotation' do
-    tree = JCR.parse( '$trule = @{not} [ ]' )
+    tree = JCR.parse( '$trule =: @{not} [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -34,7 +34,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an empty array against an empty array rule' do
-    tree = JCR.parse( '$trule = [ ]' )
+    tree = JCR.parse( '$trule =: [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [], JCR::EvalConditions.new( mapping, nil ) )
@@ -42,7 +42,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an empty {not} annotation array against an empty array rule' do
-    tree = JCR.parse( '$trule = @{not} [ ]' )
+    tree = JCR.parse( '$trule =: @{not} [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [], JCR::EvalConditions.new( mapping, nil ) )
@@ -50,7 +50,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail a non-empty array against an empty array rule' do
-    tree = JCR.parse( '$trule = [ ]' )
+    tree = JCR.parse( '$trule =: [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -58,7 +58,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass a non-empty array against an empty {not} annotation array rule' do
-    tree = JCR.parse( '$trule = @{not} [ ]' )
+    tree = JCR.parse( '$trule =: @{not} [ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -66,7 +66,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an empty array against an array rule with a string' do
-    tree = JCR.parse( '$trule = [ string ]' )
+    tree = JCR.parse( '$trule =: [ string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ ], JCR::EvalConditions.new( mapping, nil ) )
@@ -74,7 +74,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an empty array against an array rule with a string and a string' do
-    tree = JCR.parse( '$trule = [ string, string ]' )
+    tree = JCR.parse( '$trule =: [ string, string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ ], JCR::EvalConditions.new( mapping, nil ) )
@@ -82,7 +82,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an empty array against an array rule with a string or a string' do
-    tree = JCR.parse( '$trule = [ string| string ]' )
+    tree = JCR.parse( '$trule =: [ string| string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ ], JCR::EvalConditions.new( mapping, nil ) )
@@ -90,7 +90,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with one string against an array rule with a string and a string' do
-    tree = JCR.parse( '$trule = [ string, string ]' )
+    tree = JCR.parse( '$trule =: [ string, string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -98,7 +98,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with one string against an array rule with a string or a string' do
-    tree = JCR.parse( '$trule = [ string | string ]' )
+    tree = JCR.parse( '$trule =: [ string | string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -106,7 +106,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with one string against an {not} annotation array rule with a string or a string' do
-    tree = JCR.parse( '$trule = @{not} [ string | string ]' )
+    tree = JCR.parse( '$trule =: @{not} [ string | string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -114,7 +114,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with one string against an array rule with a string and an integer' do
-    tree = JCR.parse( '$trule = [ string, integer ]' )
+    tree = JCR.parse( '$trule =: [ string, integer ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -122,7 +122,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with string and integer against an array rule with a string and an integer' do
-    tree = JCR.parse( '$trule = [ string, integer ]' )
+    tree = JCR.parse( '$trule =: [ string, integer ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -130,7 +130,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with one string against an array rule with a string or a integer' do
-    tree = JCR.parse( '$trule = [ string | integer ]' )
+    tree = JCR.parse( '$trule =: [ string | integer ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -138,7 +138,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with string and integer against an array rule with a string and an integer or string' do
-    tree = JCR.parse( '$trule = [ string, ( integer | string ) ]' )
+    tree = JCR.parse( '$trule =: [ string, ( integer | string ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -146,7 +146,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with string and string against an array rule with a string and an integer or string' do
-    tree = JCR.parse( '$trule = [ string, ( integer | string ) ]' )
+    tree = JCR.parse( '$trule =: [ string, ( integer | string ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -154,7 +154,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings against an array rule with string twice' do
-    tree = JCR.parse( '$trule = [ string @2..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @2..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -162,7 +162,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings against an array rule with string once or twice' do
-    tree = JCR.parse( '$trule = [ string @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -170,7 +170,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings against an array rule with string once or twice or thrice' do
-    tree = JCR.parse( '$trule = [ string @1..3 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..3 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -178,7 +178,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with one string against an array rule with string once or twice' do
-    tree = JCR.parse( '$trule = [ string @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -186,7 +186,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with one string against an array rule with string default or twice' do
-    tree = JCR.parse( '$trule = [ string @..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -194,7 +194,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an empty array against an array rule with string default or twice' do
-    tree = JCR.parse( '$trule = [ string @..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ ], JCR::EvalConditions.new( mapping, nil ) )
@@ -202,7 +202,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with one string against an array rule with string once or default' do
-    tree = JCR.parse( '$trule = [ string @1..]' )
+    tree = JCR.parse( '$trule =: [ string @1..]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -210,7 +210,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings against an array rule with string once or default' do
-    tree = JCR.parse( '$trule = [ string @1.. ]' )
+    tree = JCR.parse( '$trule =: [ string @1.. ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -218,7 +218,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings against an array rule with string +' do
-    tree = JCR.parse( '$trule = [ string @+ ]' )
+    tree = JCR.parse( '$trule =: [ string @+ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -226,7 +226,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with a string and integer against an array rule with string once or twice' do
-    tree = JCR.parse( '$trule = [ string @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -234,7 +234,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with three strings against an array rule with string once or twice' do
-    tree = JCR.parse( '$trule = [ string @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing1", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -242,7 +242,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with three strings against an array rule with string zero or twice' do
-    tree = JCR.parse( '$trule = [ string @0..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @0..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing1", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -250,7 +250,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with five strings against an array rule with string zero or twice' do
-    tree = JCR.parse( '$trule = [ string @0..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @0..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing1", "thing2", "thing3", "thing4" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -258,7 +258,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with three strings against an array rule with string twice' do
-    tree = JCR.parse( '$trule = [ string @2..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @2..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing1", "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -266,7 +266,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with two strings and integer against an array rule with string twice' do
-    tree = JCR.parse( '$trule = [ string @2..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @2..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing1", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -274,7 +274,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with a string and integer against an array rule with string default or twice' do
-    tree = JCR.parse( '$trule = [ string @..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -282,7 +282,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with a string and integer and string against an array rule with string and integer' do
-    tree = JCR.parse( '$trule = [ string, integer ]' )
+    tree = JCR.parse( '$trule =: [ string, integer ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 2, "thing2" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -290,7 +290,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with a string against an array rule with string twice' do
-    tree = JCR.parse( '$trule = [ string @2..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @2..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -298,7 +298,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with a string and integer against an array rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, integer @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, integer @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -306,7 +306,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and integer against an array rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, integer @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, integer @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -314,7 +314,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with one string and two integer against an array rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, integer @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, integer @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 1, 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -322,7 +322,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two string and two integer against an array rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, integer @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, integer @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -330,7 +330,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two integers against an array rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, integer @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, integer @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -338,7 +338,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with one string and three integer against an array rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, integer @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, integer @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -346,7 +346,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two integers against an array rule with string 1*2 and any 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, any @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, any @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -354,7 +354,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two integers against an array rule with string * and any *' do
-    tree = JCR.parse( '$trule = [ string @*, any @* ]' )
+    tree = JCR.parse( '$trule =: [ string @*, any @* ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -362,7 +362,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two arrays against an array rule with string 1*2 and any 1*2' do
-    tree = JCR.parse( '$trule = [ string @1..2, any @1..2 ]' )
+    tree = JCR.parse( '$trule =: [ string @1..2, any @1..2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", [ 1, 2 ], [ 2, 3 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -370,7 +370,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two arrays against an array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = [ string @2, any @2 ]' )
+    tree = JCR.parse( '$trule =: [ string @2, any @2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", [ 1, 2 ], [ 2, 3 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -378,7 +378,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with one string and one arrays against an array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = [ string @2, any @2 ]' )
+    tree = JCR.parse( '$trule =: [ string @2, any @2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", [ 1, 2 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -386,7 +386,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with one string and one arrays against an {not} annotation array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = @{not} [ string @2, any @2 ]' )
+    tree = JCR.parse( '$trule =: @{not} [ string @2, any @2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", [ 1, 2 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -394,7 +394,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two arrays against an unordered array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = @{unordered} [ string @2, any @2 ]' )
+    tree = JCR.parse( '$trule =: @{unordered} [ string @2, any @2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", [ 1, 2 ], [ 2, 3 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -402,7 +402,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two arrays against an unordered array rule with string 2 and group any' do
-    tree = JCR.parse( '$trule = @{unordered} [ string @2, (any,any) ]' )
+    tree = JCR.parse( '$trule =: @{unordered} [ string @2, (any,any) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", [ 1, 2 ], [ 2, 3 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -410,7 +410,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two arrays against an unordered array rule with string 2 and named group any' do
-    tree = JCR.parse( '$trule = @{unordered} [ string@2, $grule ] ;; $grule = (any,any)' )
+    tree = JCR.parse( '$trule =: @{unordered} [ string@2, $grule ] ;; $grule = (any,any)' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", [ 1, 2 ], [ 2, 3 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -418,7 +418,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two arrays against an unordered array rule with string 2 and 2 named group any' do
-    tree = JCR.parse( '$trule = @{unordered} [ string@2, $grule @2 ] ;; $grule = (any)' )
+    tree = JCR.parse( '$trule =: @{unordered} [ string@2, $grule @2 ] ;; $grule = (any)' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", [ 1, 2 ], [ 2, 3 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -426,7 +426,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with two strings and three arrays against an unordered array rule with string 2 and 2 named group any' do
-    tree = JCR.parse( '$trule = @{unordered} [ string@2, $grule@2 ] ;; $grule = (any)' )
+    tree = JCR.parse( '$trule =: @{unordered} [ string@2, $grule@2 ] ;; $grule = (any)' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", [ 1, 2 ], [ 2, 3 ], [ 4, 5 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -434,7 +434,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass an array with two strings and two integers against an unordered array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = @{unordered} [ string@2, integer@2 ]' )
+    tree = JCR.parse( '$trule =: @{unordered} [ string@2, integer@2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, "thing", "thing2"  ], JCR::EvalConditions.new( mapping, nil ) )
@@ -442,7 +442,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail an array with two strings and two arrays against an {not} annotation, unordered array rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule = @{not} @{unordered} [ string@2, integer@2 ]' )
+    tree = JCR.parse( '$trule =: @{not} @{unordered} [ string@2, integer@2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, "thing", "thing2"  ], JCR::EvalConditions.new( mapping, nil ) )
@@ -450,7 +450,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail even with extra elements in an array' do
-    tree = JCR.parse( '$trule = [ string@2, integer@2, any@* ]' )
+    tree = JCR.parse( '$trule =: [ string@2, integer@2, any@* ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, "thing", "thing2", 23.0, 99.2  ], JCR::EvalConditions.new( mapping, nil ) )
@@ -458,7 +458,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass even with extra elements in an array' do
-    tree = JCR.parse( '$trule = [ string @2, integer @2, any@* ]' )
+    tree = JCR.parse( '$trule =: [ string @2, integer @2, any@* ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, 2, 23.0, 99.2  ], JCR::EvalConditions.new( mapping, nil ) )
@@ -466,7 +466,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with 2 string and a group of two integers' do
-    tree = JCR.parse( '$trule = [ string @2, $grule @2 ] ;; $grule = ( integer) ' )
+    tree = JCR.parse( '$trule =: [ string @2, $grule @2 ] ;; $grule = ( integer) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -474,7 +474,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail with 2 string and a group of two integers and extra integer' do
-    tree = JCR.parse( '$trule = [ string @2, $grule @2 ] ;; $grule = ( integer) ' )
+    tree = JCR.parse( '$trule =: [ string @2, $grule @2 ] ;; $grule = ( integer) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -482,7 +482,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with 2 string and a group of integer and string' do
-    tree = JCR.parse( '$trule = [ string @2, $grule ] ;; $grule = ( integer, string ) ' )
+    tree = JCR.parse( '$trule =: [ string @2, $grule ] ;; $grule = ( integer, string ) ' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "thing", "thing2", 1, "thing3" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -490,7 +490,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with ORed group each with string and repeated integer 1' do
-    tree = JCR.parse( '$arule = [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
+    tree = JCR.parse( '$arule =: [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "a", [ 1, 2 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -498,7 +498,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail with ORed group each with string and repeated integer 1' do
-    tree = JCR.parse( '$arule = [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
+    tree = JCR.parse( '$arule =: [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "a", [ 1, 2, 3, 4 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -506,7 +506,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with ORed group each with string and repeated integer 2' do
-    tree = JCR.parse( '$arule = [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
+    tree = JCR.parse( '$arule =: [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "b", [ 1, 2, 3, 4 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -514,7 +514,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail with ORed group each with string and repeated integer 2' do
-    tree = JCR.parse( '$arule = [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
+    tree = JCR.parse( '$arule =: [ ( "a", [ integer @2 ] ) | ( "b", [ integer @4 ] ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "b", [ 1, 2 ] ], JCR::EvalConditions.new( mapping, nil ) )
@@ -522,7 +522,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with three ANDs and an OR 1' do
-    tree = JCR.parse( '$arule = [ 1, 2, ( 3 | 4 ) ]' )
+    tree = JCR.parse( '$arule =: [ 1, 2, ( 3 | 4 ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -530,7 +530,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with three ANDs and an OR 2' do
-    tree = JCR.parse( '$arule = [ 1, 2, ( 3 | 4 ) ]' )
+    tree = JCR.parse( '$arule =: [ 1, 2, ( 3 | 4 ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 4 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -538,7 +538,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail with three ANDs and an OR' do
-    tree = JCR.parse( '$arule = [ 1, 2, ( 3 | 4 ) ]' )
+    tree = JCR.parse( '$arule =: [ 1, 2, ( 3 | 4 ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 4 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -546,7 +546,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with three ANDs in a group and an OR 1' do
-    tree = JCR.parse( '$arule = [ ( 1, 2, 3 ) | 4 ]' )
+    tree = JCR.parse( '$arule =: [ ( 1, 2, 3 ) | 4 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -554,7 +554,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass with three ANDs  in a group and an OR 2' do
-    tree = JCR.parse( '$arule = [ ( 1, 2, 3 ) | 4 ]' )
+    tree = JCR.parse( '$arule =: [ ( 1, 2, 3 ) | 4 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 4 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -562,7 +562,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail with three ANDs in a group and an OR' do
-    tree = JCR.parse( '$arule = [ ( 1, 2, 3 ) | 4 ]' )
+    tree = JCR.parse( '$arule =: [ ( 1, 2, 3 ) | 4 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 4 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -570,7 +570,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass unordered with three ANDs in a group and an OR 1' do
-    tree = JCR.parse( '$arule = @{unordered} [ ( 1, 2, 3 ) | 4 ]' )
+    tree = JCR.parse( '$arule =: @{unordered} [ ( 1, 2, 3 ) | 4 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 3, 2, 1 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -578,7 +578,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should pass unordered with three ANDs  in a group and an OR 2' do
-    tree = JCR.parse( '$arule = @{unordered} [ ( 1, 2, 3 ) | 4 ]' )
+    tree = JCR.parse( '$arule =: @{unordered} [ ( 1, 2, 3 ) | 4 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 4 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -586,7 +586,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should fail unordered with three ANDs in a group and an OR' do
-    tree = JCR.parse( '$arule = [ ( 1, 2, 3 ) | 4 ]' )
+    tree = JCR.parse( '$arule =: [ ( 1, 2, 3 ) | 4 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 4, 2, 1 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -594,7 +594,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should demonstrate OR and AND logic 1' do
-    tree = JCR.parse( '$arule = [ 1, 2, ( 3 | 4 ) , 5 ]' )
+    tree = JCR.parse( '$arule =: [ 1, 2, ( 3 | 4 ) , 5 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect( JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) ).success ).to be_falsey
@@ -603,7 +603,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should demonstrate OR and AND logic 2' do
-    tree = JCR.parse( '$arule = [ 1, 2, ( 3 | 4 | 5 ) ]' )
+    tree = JCR.parse( '$arule =: [ 1, 2, ( 3 | 4 | 5 ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect( JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) ).success ).to be_truthy
@@ -613,7 +613,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should demonstrate OR and AND logic 3' do
-    tree = JCR.parse( '$arule = [ 1, 2, ( 3 | 4 ), (5 | 6 ) ]' )
+    tree = JCR.parse( '$arule =: [ 1, 2, ( 3 | 4 ), (5 | 6 ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect( JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3, 5 ], JCR::EvalConditions.new( mapping, nil ) ).success ).to be_truthy
@@ -623,7 +623,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should demonstrate OR and AND logic 4' do
-    tree = JCR.parse( '$arule = [ 1, 2,( 3 | 4 ), 5, ( 6 | 7 ) ]' )
+    tree = JCR.parse( '$arule =: [ 1, 2,( 3 | 4 ), 5, ( 6 | 7 ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect( JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3, 5, 6 ], JCR::EvalConditions.new( mapping, nil ) ).success ).to be_truthy
@@ -633,7 +633,7 @@ describe 'evaluate_array_rules' do
   end
 
   it 'should demonstrate OR and AND logic 5' do
-    tree = JCR.parse( '$arule = [ ( 1 | 2 ) , ( 3 | 4 ) ]' )
+    tree = JCR.parse( '$arule =: [ ( 1 | 2 ) , ( 3 | 4 ) ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     expect( JCR.evaluate_rule( tree[0], tree[0], [ 1, 3 ], JCR::EvalConditions.new( mapping, nil ) ).success ).to be_truthy

--- a/spec/evaluate_object_rules_spec.rb
+++ b/spec/evaluate_object_rules_spec.rb
@@ -18,7 +18,7 @@ require_relative '../lib/jcr/evaluate_object_rules'
 describe 'evaluate_object_rules' do
 
   it 'should fail something that is not an object' do
-    tree = JCR.parse( '$trule= { }' )
+    tree = JCR.parse( '$trule=: { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -26,7 +26,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass something that is not an object with {not} annotation' do
-    tree = JCR.parse( '$trule= @{not} { }' )
+    tree = JCR.parse( '$trule=: @{not} { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -34,7 +34,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an empty object against an empty object rule' do
-    tree = JCR.parse( '$trule= { }' )
+    tree = JCR.parse( '$trule=type { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { }, JCR::EvalConditions.new( mapping, nil ) )
@@ -42,7 +42,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an empty object against an empty {not} annotation object rule' do
-    tree = JCR.parse( '$trule= @{not} { }' )
+    tree = JCR.parse( '$trule=: @{not} { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { }, JCR::EvalConditions.new( mapping, nil ) )
@@ -50,7 +50,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail a non-empty object against an empty object rule' do
-    tree = JCR.parse( '$trule= { }' )
+    tree = JCR.parse( '$trule=: { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"bar"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -58,7 +58,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass a non-empty object against an empty {not} annotation object rule' do
-    tree = JCR.parse( '$trule= @{not} { }' )
+    tree = JCR.parse( '$trule=: @{not} { }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"bar"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -66,7 +66,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an empty object against an object rule with a string member' do
-    tree = JCR.parse( '$trule= { "foo" :string }' )
+    tree = JCR.parse( '$trule=: { "foo" :string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { }, JCR::EvalConditions.new( mapping, nil ) )
@@ -74,7 +74,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an empty object against an object rule with a string member and a string member' do
-    tree = JCR.parse( '$trule= { "foo" :string, "bar" :string }' )
+    tree = JCR.parse( '$trule=: { "foo" :string, "bar" :string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { }, JCR::EvalConditions.new( mapping, nil ) )
@@ -82,7 +82,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an empty object against an object rule with a string member or a string member' do
-    tree = JCR.parse( '$trule= { "foo" :string| "bar" :string }' )
+    tree = JCR.parse( '$trule=: { "foo" :string| "bar" :string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { }, JCR::EvalConditions.new( mapping, nil ) )
@@ -90,7 +90,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with one string against an object rule with a string member and a string member' do
-    tree = JCR.parse( '$trule= { "foo":string, "bar":string }' )
+    tree = JCR.parse( '$trule=: { "foo":string, "bar":string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -98,7 +98,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with a string member or a string member' do
-    tree = JCR.parse( '$trule= { "foo":string | "bar":string }' )
+    tree = JCR.parse( '$trule=: { "foo":string | "bar":string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -106,7 +106,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with one string against an {not} annotation object rule with a string member or a string member' do
-    tree = JCR.parse( '$trule= @{not} { "foo":string | "bar":string }' )
+    tree = JCR.parse( '$trule=: @{not} { "foo":string | "bar":string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -114,7 +114,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with one string against an object rule with a string member and an integer member' do
-    tree = JCR.parse( '$trule= { "foo":string, "bar":integer }' )
+    tree = JCR.parse( '$trule=: { "foo":string, "bar":integer }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -122,7 +122,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with string and integer against an object rule with a string member and an integer member' do
-    tree = JCR.parse( '$trule= { "foo":string, "bar":integer }' )
+    tree = JCR.parse( '$trule=: { "foo":string, "bar":integer }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"thing", "bar"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -130,7 +130,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with a string member or a integer member' do
-    tree = JCR.parse( '$trule= { "foo":string | "bar":integer }' )
+    tree = JCR.parse( '$trule=: { "foo":string | "bar":integer }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "foo"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -138,7 +138,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with string and integer against an object rule with a string member and an integer member or string member' do
-    tree = JCR.parse( '$trule= { "bar":string, ( "foo":integer | "foo":string ) }' )
+    tree = JCR.parse( '$trule=: { "bar":string, ( "foo":integer | "foo":string ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], { "bar"=>"thing", "foo"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -146,7 +146,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with string and string against an object rule with a string member and an integer member or string member' do
-    tree = JCR.parse( '$trule= { "bar":string, ( "foo":integer | "foo":string ) }' )
+    tree = JCR.parse( '$trule=: { "bar":string, ( "foo":integer | "foo":string ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"bar"=>"thing","foo"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -154,7 +154,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string twice' do
-    tree = JCR.parse( '$trule= { /m.*/ :string @2..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/ :string @2..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -162,7 +162,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or twice' do
-    tree = JCR.parse( '$trule= { /m.*/:string @1..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -170,7 +170,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or twice or thrice' do
-    tree = JCR.parse( '$trule= { /m.*/:string @1..3 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @1..3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -178,7 +178,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member once or twice' do
-    tree = JCR.parse( '$trule= { /m.*/:string @1..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -186,7 +186,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member default or twice' do
-    tree = JCR.parse( '$trule= { /m.*/:string @..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -194,7 +194,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an empty object  against an object rule with string member default or twice' do
-    tree = JCR.parse( '$trule= { /m.*/:string @..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {}, JCR::EvalConditions.new( mapping, nil ) )
@@ -202,7 +202,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member once or default' do
-    tree = JCR.parse( '$trule= { /m.*/:string @1.. }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @1.. }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -210,7 +210,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or default' do
-    tree = JCR.parse( '$trule= { /m.*/:string @1.. }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @1.. }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -218,7 +218,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member one or more' do
-    tree = JCR.parse( '$trule= { /m.*/:string @+ }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @+ }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -226,7 +226,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string member once or twice (ignore extras)' do
-    tree = JCR.parse( '$trule= { /m.*/:string @1..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing","m2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -234,7 +234,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string member default or twice (ignore extras)' do
-    tree = JCR.parse( '$trule= { /m.*/:string @..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -242,7 +242,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer and string against an object rule with string and integer (ignore extra)' do
-    tree = JCR.parse( '$trule= { "foo":string, "bar":integer }' )
+    tree = JCR.parse( '$trule=: { "foo":string, "bar":integer }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"foo"=>"thing","bar"=>2,"foo2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -250,7 +250,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with a string against an object rule with string twice' do
-    tree = JCR.parse( '$trule= { /m.*/:string @2..2 }' )
+    tree = JCR.parse( '$trule=: { /m.*/:string @2..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -258,7 +258,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule= { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing", "i1"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -266,7 +266,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule= { /s.*/:string@1..2, /i.*/:integer @1..2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string@1..2, /i.*/:integer @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -274,7 +274,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string and two integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule= { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -282,7 +282,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two string and two integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule= { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -290,7 +290,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule= { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -298,7 +298,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with one string and three integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule= { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @1..2, /i.*/:integer @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","i1"=> 1,"i2"=> 2,"i3"=> 3 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -306,7 +306,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 1*2 and any 1*2' do
-    tree = JCR.parse( '$trule= { /s.*/:string @1..2, /.*/:integer @1..2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @1..2, /.*/:integer @1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -314,7 +314,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule= { /s.*/:string @2, /.*/:integer @2 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @2, /.*/:integer @2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -322,7 +322,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string + and any +' do
-    tree = JCR.parse( '$trule= { /s.*/:string @+, /.*/:integer @+ }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @+, /.*/:integer @+ }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -330,7 +330,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with two strings and two integers against an object rule with string ? and any ?' do
-    tree = JCR.parse( '$trule= { /s.*/:string @?, /.*/:integer @? }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @?, /.*/:integer @? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -338,7 +338,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one strings and one integers against an object rule with string ? and any ?' do
-    tree = JCR.parse( '$trule= { /s.*/:string @?, /.*/:integer @? }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @?, /.*/:integer @? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","1"=> 1 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -346,7 +346,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with two members against an object rule with overlapping rules' do
-    tree = JCR.parse( '$trule= { /.*/:any @2, /.*/:any @1 }' )
+    tree = JCR.parse( '$trule=: { /.*/:any @2, /.*/:any @1 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","1"=> 1 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -354,7 +354,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should ignore extra members in an object' do
-    tree = JCR.parse( '$trule= { /s.*/:string @2, "foo":integer @1 }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string @2, "foo":integer @1 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2,"bar"=>"baz" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -362,7 +362,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should not ignore extra members in an object' do
-    tree = JCR.parse( '$trule= { /s.*/:string@2, "foo":integer@1, @{not} /.*/:any@+ }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string@2, "foo":integer@1, @{not} /.*/:any@+ }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2,"bar"=>"baz" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -370,7 +370,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with not extra members using {not} annotation' do
-    tree = JCR.parse( '$trule= { /s.*/:string@2, "foo":integer@1, @{not} /.*/:any @? }' )
+    tree = JCR.parse( '$trule=: { /s.*/:string@2, "foo":integer@1, @{not} /.*/:any @? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -378,7 +378,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with string member and object member' do
-    tree = JCR.parse( '$trule= { "s1":string, "o1" :{ "ss1":string } }' )
+    tree = JCR.parse( '$trule=: { "s1":string, "o1" :{ "ss1":string } }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","o1"=>{"ss1"=>"thing2"} }, JCR::EvalConditions.new( mapping, nil ) )
@@ -386,7 +386,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with a string member and group member containing a string member' do
-    tree = JCR.parse( '$trule= { "s1":string, ( "s2":string ) }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( "s2":string ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -394,7 +394,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with 2 ORed groups of ANDs 1' do
-    tree = JCR.parse( '$trule= { ("s1":string, "s2":string ) | ( "s3":string , "s4":string ) }' )
+    tree = JCR.parse( '$trule=: { ("s1":string, "s2":string ) | ( "s3":string , "s4":string ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -402,7 +402,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with 2 ORed groups of ANDs 2' do
-    tree = JCR.parse( '$trule= { ("s1":string, "s2":string ) | ( "s3":string , "s4":string ) }' )
+    tree = JCR.parse( '$trule=: { ("s1":string, "s2":string ) | ( "s3":string , "s4":string ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s3"=> "thing","s4"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -410,7 +410,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object with 2 ORed groups of ANDs 2' do
-    tree = JCR.parse( '$trule= { ("s1":string, "s2":string ) | ( "s3":string , "s4":string ) }' )
+    tree = JCR.parse( '$trule=: { ("s1":string, "s2":string ) | ( "s3":string , "s4":string ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s5"=> "thing","s6"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -418,7 +418,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with simple nested groups' do
-    tree = JCR.parse( '$trule= { ( ("s1":string, "s2":string ) ) }' )
+    tree = JCR.parse( '$trule=: { ( ("s1":string, "s2":string ) ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -426,7 +426,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with complex nested groups 1' do
-    tree = JCR.parse( '$trule= { ( ( "s1":string, "s2":string ) | ( "s3":string ) ) , "s4":string }' )
+    tree = JCR.parse( '$trule=: { ( ( "s1":string, "s2":string ) | ( "s3":string ) ) , "s4":string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=>"foo", "s2"=> "thing","s4"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -434,7 +434,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with complex nested groups 2' do
-    tree = JCR.parse( '$trule= { ( ( "s1":string, "s2":string ) | ( "s3":string ) ) , "s4":string }' )
+    tree = JCR.parse( '$trule=: { ( ( "s1":string, "s2":string ) | ( "s3":string ) ) , "s4":string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s3"=>"fuzz", "s4"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -442,7 +442,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object with complex nested groups 1' do
-    tree = JCR.parse( '$trule= { ( ( "s1":string, "s2":string ) | ( "s3":string ) ) , "s4":string }' )
+    tree = JCR.parse( '$trule=: { ( ( "s1":string, "s2":string ) | ( "s3":string ) ) , "s4":string }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s0"=>"fizz", "s4"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -450,7 +450,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with complex nested groups with a named rule 1' do
-    tree = JCR.parse( '$orule = { ( $trule | ( "s3":string ) ) , "s4":string } ;; $trule = ( "s1":string, "s2":string )' )
+    tree = JCR.parse( '$orule =: { ( $trule | ( "s3":string ) ) , "s4":string } ;; $trule = ( "s1":string, "s2":string )' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=>"foo", "s2"=> "thing","s4"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -458,7 +458,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with ORed groups of overlapping member rules 1' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -467,7 +467,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with ORed groups of overlapping member rules 2' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -476,7 +476,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with ORed groups of overlapping member rules 3' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -485,7 +485,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object with ORed groups of overlapping member rules 3' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $c ) | ( $b, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -494,7 +494,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with ORed groups with manditory member but optional if another exists 1' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $b@?, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $b@?, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -503,7 +503,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object with ORed groups with manditory member but optional if another exists 1' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $b@?, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $b@?, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -512,7 +512,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with ORed groups with manditory member but optional if another exists 2' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $b@?, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $b@?, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
@@ -521,7 +521,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with ORed groups with manditory member but optional if another exists 3' do
-    tree = JCR.parse( '$orule = { ( $a, $b ) | ( $a, $b@?, $c ) }'\
+    tree = JCR.parse( '$orule =: { ( $a, $b ) | ( $a, $b@?, $c ) }'\
                       '$a = "a":string $b = "b":string $c = "c":string')
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )

--- a/spec/evaluate_rules_spec.rb
+++ b/spec/evaluate_rules_spec.rb
@@ -22,7 +22,7 @@ describe 'evaluate_rules' do
   #
 
   it 'should see an optional as min 0 max 1' do
-    tree = JCR.parse( '$trule= [ string @? ]' )
+    tree = JCR.parse( '$trule=: [ string @? ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     min, max = JCR.get_repetitions( tree[0][:rule][:array_rule], JCR::EvalConditions.new( nil, nil ) )
@@ -31,7 +31,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should see a one or more as min 1 max infinity' do
-    tree = JCR.parse( '$trule= [ string @+ ]' )
+    tree = JCR.parse( '$trule=: [ string @+ ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     min, max = JCR.get_repetitions( tree[0][:rule][:array_rule], JCR::EvalConditions.new( nil, nil ) )
@@ -40,7 +40,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should see a zero or more as min 0 max infinity' do
-    tree = JCR.parse( '$trule= [ string @* ]' )
+    tree = JCR.parse( '$trule=: [ string @* ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     min, max = JCR.get_repetitions( tree[0][:rule][:array_rule], JCR::EvalConditions.new( nil, nil ) )
@@ -49,7 +49,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should see a 1 to 4 as min 1 max 4' do
-    tree = JCR.parse( '$trule= [ string @1..4 ]' )
+    tree = JCR.parse( '$trule=: [ string @1..4 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     min, max = JCR.get_repetitions( tree[0][:rule][:array_rule], JCR::EvalConditions.new( nil, nil ) )
@@ -58,7 +58,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should see 22 as min 22 max 22' do
-    tree = JCR.parse( '$trule= [ string @22 ]' )
+    tree = JCR.parse( '$trule=: [ string @22 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     min, max = JCR.get_repetitions( tree[0][:rule][:array_rule], JCR::EvalConditions.new( nil, nil ) )
@@ -67,7 +67,7 @@ describe 'evaluate_rules' do
   end
 
   it 'should see nothing as min 1 max 1' do
-    tree = JCR.parse( '$trule= [ string ]' )
+    tree = JCR.parse( '$trule=: [ string ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     min, max = JCR.get_repetitions( tree[0][:rule][:array_rule], JCR::EvalConditions.new( nil, nil ) )

--- a/spec/evaluate_value_rules_spec.rb
+++ b/spec/evaluate_value_rules_spec.rb
@@ -23,7 +23,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass when any rule matches a string constant' do
-    tree = JCR.parse( '$trule= any' )
+    tree = JCR.parse( '$trule=: any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -31,7 +31,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass when any rule matches an object' do
-    tree = JCR.parse( '$trule= any' )
+    tree = JCR.parse( '$trule=: any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"foo"=>"bar"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -39,7 +39,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass when any rule matches an array' do
-    tree = JCR.parse( '$trule= any' )
+    tree = JCR.parse( '$trule=: any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -47,7 +47,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail when any rule matches an array with {not} annotation' do
-    tree = JCR.parse( '$trule= @{not} any' )
+    tree = JCR.parse( '$trule=: @{not} any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ 1, 2, 3 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -59,7 +59,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass when a string matches a string constant' do
-    tree = JCR.parse( '$trule= "a string constant"' )
+    tree = JCR.parse( '$trule=: "a string constant"' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -67,7 +67,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail when a string matches a string constant with {not} annotation' do
-    tree = JCR.parse( '$trule= @{not} "a string constant"' )
+    tree = JCR.parse( '$trule=: @{not} "a string constant"' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -75,7 +75,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail when a string does not match a string constant' do
-    tree = JCR.parse( '$trule= "a string constant"' )
+    tree = JCR.parse( '$trule=: "a string constant"' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "another string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -83,7 +83,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a string variable' do
-    tree = JCR.parse( '$trule= string' )
+    tree = JCR.parse( '$trule=: string' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "a string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -91,7 +91,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string variable defined as a constant' do
-    tree = JCR.parse( '$trule= "a string constant"' )
+    tree = JCR.parse( '$trule=: "a string constant"' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "another string constant", JCR::EvalConditions.new( mapping, nil ) )
@@ -103,7 +103,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass an integer variable' do
-    tree = JCR.parse( '$trule= integer' )
+    tree = JCR.parse( '$trule=: integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -111,7 +111,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an integer variable when passed a string' do
-    tree = JCR.parse( '$trule= integer' )
+    tree = JCR.parse( '$trule=: integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -119,7 +119,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an integer variable matching a constant' do
-    tree = JCR.parse( '$trule= 3' )
+    tree = JCR.parse( '$trule=: 3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 3, JCR::EvalConditions.new( mapping, nil ) )
@@ -127,7 +127,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an integer variable not matching a constant' do
-    tree = JCR.parse( '$trule=  3' )
+    tree = JCR.parse( '$trule=:  3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -135,7 +135,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an integer variable when passed a string' do
-    tree = JCR.parse( '$trule= 3' )
+    tree = JCR.parse( '$trule=: 3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -143,7 +143,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an integer within a range' do
-    tree = JCR.parse( '$trule= 1..3' )
+    tree = JCR.parse( '$trule=: 1..3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -151,7 +151,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an integer below a range' do
-    tree = JCR.parse( '$trule= 1..3' )
+    tree = JCR.parse( '$trule=: 1..3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 0, JCR::EvalConditions.new( mapping, nil ) )
@@ -159,7 +159,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an integer above a range' do
-    tree = JCR.parse( '$trule= 1..3' )
+    tree = JCR.parse( '$trule=: 1..3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 4, JCR::EvalConditions.new( mapping, nil ) )
@@ -167,7 +167,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an integer at the min of a range' do
-    tree = JCR.parse( '$trule= 1..3' )
+    tree = JCR.parse( '$trule=: 1..3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 1, JCR::EvalConditions.new( mapping, nil ) )
@@ -175,7 +175,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an integer at the max of a range' do
-    tree = JCR.parse( '$trule= 1..3' )
+    tree = JCR.parse( '$trule=: 1..3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 3, JCR::EvalConditions.new( mapping, nil ) )
@@ -183,7 +183,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an integer range when passed a string' do
-    tree = JCR.parse( '$trule= 1..3' )
+    tree = JCR.parse( '$trule=: 1..3' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -191,7 +191,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized integer within a range' do
-    tree = JCR.parse( '$trule= int8' )
+    tree = JCR.parse( '$trule=: int8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 100, JCR::EvalConditions.new( mapping, nil ) )
@@ -199,7 +199,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a negative sized integer within a range' do
-    tree = JCR.parse( '$trule= int8' )
+    tree = JCR.parse( '$trule=: int8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], -100, JCR::EvalConditions.new( mapping, nil ) )
@@ -207,7 +207,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized integer below a range' do
-    tree = JCR.parse( '$trule= int8' )
+    tree = JCR.parse( '$trule=: int8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], -129, JCR::EvalConditions.new( mapping, nil ) )
@@ -215,7 +215,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized integer above a range' do
-    tree = JCR.parse( '$trule= int8' )
+    tree = JCR.parse( '$trule=: int8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 128, JCR::EvalConditions.new( mapping, nil ) )
@@ -223,7 +223,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized integer at the min of a range' do
-    tree = JCR.parse( '$trule= int8' )
+    tree = JCR.parse( '$trule=: int8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], -128, JCR::EvalConditions.new( mapping, nil ) )
@@ -231,7 +231,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized integer at the max of a range' do
-    tree = JCR.parse( '$trule= int8' )
+    tree = JCR.parse( '$trule=: int8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 127, JCR::EvalConditions.new( mapping, nil ) )
@@ -239,7 +239,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized integer below a range' do
-    tree = JCR.parse( '$trule= int16' )
+    tree = JCR.parse( '$trule=: int16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], -32769, JCR::EvalConditions.new( mapping, nil ) )
@@ -247,7 +247,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized integer above a range' do
-    tree = JCR.parse( '$trule= int16' )
+    tree = JCR.parse( '$trule=: int16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 32768, JCR::EvalConditions.new( mapping, nil ) )
@@ -255,7 +255,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized integer at the min of a range' do
-    tree = JCR.parse( '$trule= int16' )
+    tree = JCR.parse( '$trule=: int16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], -32768, JCR::EvalConditions.new( mapping, nil ) )
@@ -263,7 +263,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized integer at the max of a range' do
-    tree = JCR.parse( '$trule= int16' )
+    tree = JCR.parse( '$trule=: int16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 32767, JCR::EvalConditions.new( mapping, nil ) )
@@ -271,7 +271,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized integer range when passed a string' do
-    tree = JCR.parse( '$trule= int8' )
+    tree = JCR.parse( '$trule=: int8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -279,7 +279,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized unsigned integer within a range' do
-    tree = JCR.parse( '$trule= uint8' )
+    tree = JCR.parse( '$trule=: uint8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 100, JCR::EvalConditions.new( mapping, nil ) )
@@ -287,7 +287,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized unsigned integer below a range' do
-    tree = JCR.parse( '$trule= uint8' )
+    tree = JCR.parse( '$trule=: uint8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], -1, JCR::EvalConditions.new( mapping, nil ) )
@@ -295,7 +295,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized unsigned integer above a range' do
-    tree = JCR.parse( '$trule= uint8' )
+    tree = JCR.parse( '$trule=: uint8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 256, JCR::EvalConditions.new( mapping, nil ) )
@@ -303,7 +303,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized unsigned integer at the min of a range' do
-    tree = JCR.parse( '$trule= uint8' )
+    tree = JCR.parse( '$trule=: uint8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 0, JCR::EvalConditions.new( mapping, nil ) )
@@ -311,7 +311,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized unsigned integer at the max of a range' do
-    tree = JCR.parse( '$trule= uint8' )
+    tree = JCR.parse( '$trule=: uint8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 255, JCR::EvalConditions.new( mapping, nil ) )
@@ -319,7 +319,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized unsigned integer below a range' do
-    tree = JCR.parse( '$trule= uint16' )
+    tree = JCR.parse( '$trule=: uint16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], -1, JCR::EvalConditions.new( mapping, nil ) )
@@ -327,7 +327,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized unsigned integer above a range' do
-    tree = JCR.parse( '$trule= uint16' )
+    tree = JCR.parse( '$trule=: uint16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 65536, JCR::EvalConditions.new( mapping, nil ) )
@@ -335,7 +335,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized unsigned integer at the min of a range' do
-    tree = JCR.parse( '$trule= uint16' )
+    tree = JCR.parse( '$trule=: uint16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 0, JCR::EvalConditions.new( mapping, nil ) )
@@ -343,7 +343,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a sized unsigned integer at the max of a range' do
-    tree = JCR.parse( '$trule= uint16' )
+    tree = JCR.parse( '$trule=: uint16' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 65535, JCR::EvalConditions.new( mapping, nil ) )
@@ -351,7 +351,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a sized unsigned integer range when passed a string' do
-    tree = JCR.parse( '$trule= uint8' )
+    tree = JCR.parse( '$trule=: uint8' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -363,7 +363,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a double variable' do
-    tree = JCR.parse( '$trule= double' )
+    tree = JCR.parse( '$trule=: double' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -371,7 +371,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a double variable when passed a string' do
-    tree = JCR.parse( '$trule= double' )
+    tree = JCR.parse( '$trule=: double' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -379,7 +379,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a float variable' do
-    tree = JCR.parse( '$trule= float' )
+    tree = JCR.parse( '$trule=: float' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -387,7 +387,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a float variable when passed a string' do
-    tree = JCR.parse( '$trule= float' )
+    tree = JCR.parse( '$trule=: float' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -395,7 +395,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a float variable matching a constant' do
-    tree = JCR.parse( '$trule= 3.1' )
+    tree = JCR.parse( '$trule=: 3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 3.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -403,7 +403,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an float variable not matching a constant' do
-    tree = JCR.parse( '$trule= 3.1' )
+    tree = JCR.parse( '$trule=: 3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -411,7 +411,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an float exact when passed a string' do
-    tree = JCR.parse( '$trule= 3.1' )
+    tree = JCR.parse( '$trule=: 3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -419,7 +419,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an float within a range' do
-    tree = JCR.parse( '$trule= 1.1..3.1' )
+    tree = JCR.parse( '$trule=: 1.1..3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -427,7 +427,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an float below a range' do
-    tree = JCR.parse( '$trule= 1.1..3.1' )
+    tree = JCR.parse( '$trule=: 1.1..3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 0.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -435,7 +435,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an float above a range' do
-    tree = JCR.parse( '$trule= 1.1..3.1' )
+    tree = JCR.parse( '$trule=: 1.1..3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 4.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -443,7 +443,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an float at the min of a range' do
-    tree = JCR.parse( '$trule= 1.1..3.1' )
+    tree = JCR.parse( '$trule=: 1.1..3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 1.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -451,7 +451,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an float at the max of a range' do
-    tree = JCR.parse( '$trule= 1.1..3.1' )
+    tree = JCR.parse( '$trule=: 1.1..3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 3.1, JCR::EvalConditions.new( mapping, nil ) )
@@ -459,7 +459,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an float range when passed a string' do
-    tree = JCR.parse( '$trule= 1.1..3.1' )
+    tree = JCR.parse( '$trule=: 1.1..3.1' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "foo", JCR::EvalConditions.new( mapping, nil ) )
@@ -471,7 +471,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a false as a boolean' do
-    tree = JCR.parse( '$trule= boolean' )
+    tree = JCR.parse( '$trule=: boolean' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], false, JCR::EvalConditions.new( mapping, nil ) )
@@ -479,7 +479,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a true as a boolean' do
-    tree = JCR.parse( '$trule= boolean' )
+    tree = JCR.parse( '$trule=: boolean' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], true, JCR::EvalConditions.new( mapping, nil ) )
@@ -487,7 +487,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a true as a true' do
-    tree = JCR.parse( '$trule= true' )
+    tree = JCR.parse( '$trule=: true' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], true, JCR::EvalConditions.new( mapping, nil ) )
@@ -495,7 +495,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a false as a false' do
-    tree = JCR.parse( '$trule= false' )
+    tree = JCR.parse( '$trule=: false' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], false, JCR::EvalConditions.new( mapping, nil ) )
@@ -503,7 +503,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a false as a true' do
-    tree = JCR.parse( '$trule= true' )
+    tree = JCR.parse( '$trule=: true' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], false, JCR::EvalConditions.new( mapping, nil ) )
@@ -511,7 +511,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a true as a false' do
-    tree = JCR.parse( '$trule= false' )
+    tree = JCR.parse( '$trule=: false' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], true, JCR::EvalConditions.new( mapping, nil ) )
@@ -523,7 +523,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a null' do
-    tree = JCR.parse( '$trule= null' )
+    tree = JCR.parse( '$trule=: null' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], nil, JCR::EvalConditions.new( mapping, nil ) )
@@ -531,7 +531,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a null with {not} annotation' do
-    tree = JCR.parse( '$trule= @{not} null' )
+    tree = JCR.parse( '$trule=: @{not} null' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], nil, JCR::EvalConditions.new( mapping, nil ) )
@@ -543,7 +543,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a string matching a regular expression' do
-    tree = JCR.parse( '$trule= /[a-z]*/' )
+    tree = JCR.parse( '$trule=: /[a-z]*/' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "aaa", JCR::EvalConditions.new( mapping, nil ) )
@@ -551,7 +551,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string not matching a regular expression' do
-    tree = JCR.parse( '$trule= /[a-z]*/' )
+    tree = JCR.parse( '$trule=: /[a-z]*/' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "AAA", JCR::EvalConditions.new( mapping, nil ) )
@@ -559,7 +559,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number not matching a regular expression' do
-    tree = JCR.parse( '$trule= /[a-z]*/' )
+    tree = JCR.parse( '$trule=: /[a-z]*/' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -571,7 +571,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass an IPv4 address that matches' do
-    tree = JCR.parse( '$trule= ipv4' )
+    tree = JCR.parse( '$trule=: ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -579,7 +579,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv4 address that does not match' do
-    tree = JCR.parse( '$trule= ipv4' )
+    tree = JCR.parse( '$trule=: ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -587,7 +587,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv4 address that is not a string' do
-    tree = JCR.parse( '$trule= ipv4' )
+    tree = JCR.parse( '$trule=: ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -595,7 +595,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv4 address that is suppose to be an IPv6 address' do
-    tree = JCR.parse( '$trule= ipv6' )
+    tree = JCR.parse( '$trule=: ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -603,7 +603,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an IPv6 address that matches' do
-    tree = JCR.parse( '$trule= ipv6' )
+    tree = JCR.parse( '$trule=: ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1", JCR::EvalConditions.new( mapping, nil ) )
@@ -611,7 +611,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a fully expanded IPv6 address that matches' do
-    tree = JCR.parse( '$trule= ipv6' )
+    tree = JCR.parse( '$trule=: ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000:0000:0000:0000:0000:0000:0001", JCR::EvalConditions.new( mapping, nil ) )
@@ -619,7 +619,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv6 address that does not match' do
-    tree = JCR.parse( '$trule= ipv6' )
+    tree = JCR.parse( '$trule=: ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1....", JCR::EvalConditions.new( mapping, nil ) )
@@ -627,7 +627,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv6 address that is not a string' do
-    tree = JCR.parse( '$trule= ipv6' )
+    tree = JCR.parse( '$trule=: ipv6' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [], JCR::EvalConditions.new( mapping, nil ) )
@@ -635,7 +635,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an IPv6 address that is suppose to be an IPv4 address' do
-    tree = JCR.parse( '$trule= ipv4' )
+    tree = JCR.parse( '$trule=: ipv4' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1", JCR::EvalConditions.new( mapping, nil ) )
@@ -643,7 +643,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an ipaddr that matches an IPv4 address' do
-    tree = JCR.parse( '$trule= ipaddr' )
+    tree = JCR.parse( '$trule=: ipaddr' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -651,7 +651,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass an ipaddr that matches an IPv6 address' do
-    tree = JCR.parse( '$trule= ipaddr' )
+    tree = JCR.parse( '$trule=: ipaddr' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1", JCR::EvalConditions.new( mapping, nil ) )
@@ -659,7 +659,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an ipaddr address that is not a string' do
-    tree = JCR.parse( '$trule= ipaddr' )
+    tree = JCR.parse( '$trule=: ipaddr' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [], JCR::EvalConditions.new( mapping, nil ) )
@@ -667,7 +667,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an ipaddr address that does not match' do
-    tree = JCR.parse( '$trule= ipaddr' )
+    tree = JCR.parse( '$trule=: ipaddr' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "192.1.1.1.1.1.1", JCR::EvalConditions.new( mapping, nil ) )
@@ -675,7 +675,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an ipaddr that does not match' do
-    tree = JCR.parse( '$trule= ipaddr' )
+    tree = JCR.parse( '$trule=: ipaddr' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "2001:0000::1....", JCR::EvalConditions.new( mapping, nil ) )
@@ -687,7 +687,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass fqdn as fqdn' do
-    tree = JCR.parse( '$trule= fqdn' )
+    tree = JCR.parse( '$trule=: fqdn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.example.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -695,7 +695,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a domain label that is not a string' do
-    tree = JCR.parse( '$trule= fqdn' )
+    tree = JCR.parse( '$trule=: fqdn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 22, JCR::EvalConditions.new( mapping, nil ) )
@@ -703,7 +703,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a domain label starting with a dash' do
-    tree = JCR.parse( '$trule= fqdn' )
+    tree = JCR.parse( '$trule=: fqdn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.-example.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -711,7 +711,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a domain label ending with a dash' do
-    tree = JCR.parse( '$trule= fqdn' )
+    tree = JCR.parse( '$trule=: fqdn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.example-.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -719,7 +719,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a domain label containgin an underscore' do
-    tree = JCR.parse( '$trule= fqdn' )
+    tree = JCR.parse( '$trule=: fqdn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.example_fail.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -727,7 +727,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass idn as idn' do
-    tree = JCR.parse( '$trule= idn' )
+    tree = JCR.parse( '$trule=: idn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.e\u0092xample.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -735,7 +735,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an idn as fqdn' do
-    tree = JCR.parse( '$trule= fqdn' )
+    tree = JCR.parse( '$trule=: fqdn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.e\u0092xample.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -743,7 +743,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a fqdn as idn' do
-    tree = JCR.parse( '$trule=  idn' )
+    tree = JCR.parse( '$trule=:  idn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.example.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -751,7 +751,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an idn label starting with a dash' do
-    tree = JCR.parse( '$trule=  idn' )
+    tree = JCR.parse( '$trule=:  idn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.-e\u0092xample.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -759,7 +759,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an idn that is not a string' do
-    tree = JCR.parse( '$trule=  idn' )
+    tree = JCR.parse( '$trule=:  idn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -767,7 +767,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a idn label ending with a dash' do
-    tree = JCR.parse( '$trule=  idn' )
+    tree = JCR.parse( '$trule=:  idn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.e\u0092xample-.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -775,7 +775,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an idn label containgin an underscore' do
-    tree = JCR.parse( '$trule=  idn' )
+    tree = JCR.parse( '$trule=:  idn' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "www.e\u0092xample_fail.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -787,7 +787,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a URI' do
-    tree = JCR.parse( '$trule=  uri' )
+    tree = JCR.parse( '$trule=:  uri' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "http://example.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -795,7 +795,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a URI that is not a string' do
-    tree = JCR.parse( '$trule=  uri' )
+    tree = JCR.parse( '$trule=:  uri' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -803,7 +803,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a URI template' do
-    tree = JCR.parse( '$trule= uri..http://example.com/{?query*}' )
+    tree = JCR.parse( '$trule=: uri..http://example.com/{?query*}' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "http://example.com/?foo=bar", JCR::EvalConditions.new( mapping, nil ) )
@@ -811,7 +811,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a non-matching URI template' do
-    tree = JCR.parse( '$trule= uri..http://example.com/{?query*}' )
+    tree = JCR.parse( '$trule=: uri..http://example.com/{?query*}' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "http://example.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -819,7 +819,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a non-string against URI template' do
-    tree = JCR.parse( '$trule= uri..http://example.com/{?query*}' )
+    tree = JCR.parse( '$trule=: uri..http://example.com/{?query*}' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {}, JCR::EvalConditions.new( mapping, nil ) )
@@ -831,7 +831,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass an email address match' do
-    tree = JCR.parse( '$trule= email' )
+    tree = JCR.parse( '$trule=: email' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "example@example.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -839,7 +839,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an email address mismatch' do
-    tree = JCR.parse( '$trule= email' )
+    tree = JCR.parse( '$trule=: email' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "example@example@example.com", JCR::EvalConditions.new( mapping, nil ) )
@@ -847,7 +847,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail an email address when it is not a string' do
-    tree = JCR.parse( '$trule= email' )
+    tree = JCR.parse( '$trule=: email' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -859,7 +859,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a phone number match' do
-    tree = JCR.parse( '$trule= phone' )
+    tree = JCR.parse( '$trule=: phone' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "+34634976090", JCR::EvalConditions.new( mapping, nil ) )
@@ -867,7 +867,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a phone number mismatch' do
-    tree = JCR.parse( '$trule= phone' )
+    tree = JCR.parse( '$trule=: phone' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "123", JCR::EvalConditions.new( mapping, nil ) )
@@ -875,7 +875,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a phone number when a non-string datatype is given' do
-    tree = JCR.parse( '$trule= phone' )
+    tree = JCR.parse( '$trule=: phone' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -887,7 +887,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a hex string' do
-    tree = JCR.parse( '$trule= hex' )
+    tree = JCR.parse( '$trule=: hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1234AB", JCR::EvalConditions.new( mapping, nil ) )
@@ -895,7 +895,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a empty hex string' do
-    tree = JCR.parse( '$trule= hex' )
+    tree = JCR.parse( '$trule=: hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
@@ -903,7 +903,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number that is not a hex string' do
-    tree = JCR.parse( '$trule= hex' )
+    tree = JCR.parse( '$trule=: hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -911,7 +911,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string with illegal hex characters' do
-    tree = JCR.parse( '$trule= hex' )
+    tree = JCR.parse( '$trule=: hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1234GH", JCR::EvalConditions.new( mapping, nil ) )
@@ -919,7 +919,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a hex string that does not have even length' do
-    tree = JCR.parse( '$trule= hex' )
+    tree = JCR.parse( '$trule=: hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "12345", JCR::EvalConditions.new( mapping, nil ) )
@@ -931,7 +931,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a base32hex string' do
-    tree = JCR.parse( '$trule= base32hex' )
+    tree = JCR.parse( '$trule=: base32hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFV3", JCR::EvalConditions.new( mapping, nil ) )
@@ -939,7 +939,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a empty base32hex string' do
-    tree = JCR.parse( '$trule= base32hex' )
+    tree = JCR.parse( '$trule=: base32hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
@@ -947,7 +947,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number that is not a base32hex string' do
-    tree = JCR.parse( '$trule= base32hex' )
+    tree = JCR.parse( '$trule=: base32hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -955,7 +955,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string with illegal base32hex characters' do
-    tree = JCR.parse( '$trule= base32hex' )
+    tree = JCR.parse( '$trule=: base32hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFCZ", JCR::EvalConditions.new( mapping, nil ) )
@@ -963,7 +963,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a base32hex string if length is not multiple of 8' do
-    tree = JCR.parse( '$trule= base32hex' )
+    tree = JCR.parse( '$trule=: base32hex' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "ABCD", JCR::EvalConditions.new( mapping, nil ) )
@@ -975,7 +975,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a base32 string' do
-    tree = JCR.parse( '$trule= base32' )
+    tree = JCR.parse( '$trule=: base32' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFZ3", JCR::EvalConditions.new( mapping, nil ) )
@@ -983,7 +983,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a empty base32 string' do
-    tree = JCR.parse( '$trule= base32' )
+    tree = JCR.parse( '$trule=: base32' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
@@ -991,7 +991,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number that is not a base32 string' do
-    tree = JCR.parse( '$trule= base32' )
+    tree = JCR.parse( '$trule=: base32' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -999,7 +999,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string with illegal base32 characters' do
-    tree = JCR.parse( '$trule= base32' )
+    tree = JCR.parse( '$trule=: base32' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "ABcdEFZ1", JCR::EvalConditions.new( mapping, nil ) )
@@ -1007,7 +1007,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a base32 string if length is not multiple of 8' do
-    tree = JCR.parse( '$trule= base32' )
+    tree = JCR.parse( '$trule=: base32' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "ABCD", JCR::EvalConditions.new( mapping, nil ) )
@@ -1019,7 +1019,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a base64 string' do
-    tree = JCR.parse( '$trule= base64' )
+    tree = JCR.parse( '$trule=: base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "VGVz+/==", JCR::EvalConditions.new( mapping, nil ) )
@@ -1027,7 +1027,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a empty base64 string' do
-    tree = JCR.parse( '$trule= base64' )
+    tree = JCR.parse( '$trule=: base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
@@ -1035,7 +1035,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number that is not a base64 string' do
-    tree = JCR.parse( '$trule= base64' )
+    tree = JCR.parse( '$trule=: base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -1043,7 +1043,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string with illegal base64 characters' do
-    tree = JCR.parse( '$trule= base64' )
+    tree = JCR.parse( '$trule=: base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "VGVzA%==", JCR::EvalConditions.new( mapping, nil ) )
@@ -1051,7 +1051,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string with base64 characters after padding' do
-    tree = JCR.parse( '$trule= base64' )
+    tree = JCR.parse( '$trule=: base64' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaaa", JCR::EvalConditions.new( mapping, nil ) )
@@ -1063,7 +1063,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a base64url string' do
-    tree = JCR.parse( '$trule= base64url' )
+    tree = JCR.parse( '$trule=: base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "VGVz-_==", JCR::EvalConditions.new( mapping, nil ) )
@@ -1071,7 +1071,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a empty base64url string' do
-    tree = JCR.parse( '$trule= base64url' )
+    tree = JCR.parse( '$trule=: base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "", JCR::EvalConditions.new( mapping, nil ) )
@@ -1079,7 +1079,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number that is not a base64url string' do
-    tree = JCR.parse( '$trule= base64url' )
+    tree = JCR.parse( '$trule=: base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -1087,7 +1087,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string with illegal base64url characters' do
-    tree = JCR.parse( '$trule= base64url' )
+    tree = JCR.parse( '$trule=: base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "VGVzA%==", JCR::EvalConditions.new( mapping, nil ) )
@@ -1095,7 +1095,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a string with base64url characters after padding' do
-    tree = JCR.parse( '$trule= base64url' )
+    tree = JCR.parse( '$trule=: base64url' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "VGVzdA==aaaa", JCR::EvalConditions.new( mapping, nil ) )
@@ -1107,7 +1107,7 @@ describe 'evaluate_value_rules' do
   #
 
   it 'should pass a datetime string' do
-    tree = JCR.parse( '$trule= datetime' )
+    tree = JCR.parse( '$trule=: datetime' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-04-12T23:20:50.52Z", JCR::EvalConditions.new( mapping, nil ) )
@@ -1115,7 +1115,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number being passed as datetime' do
-    tree = JCR.parse( '$trule= datetime' )
+    tree = JCR.parse( '$trule=: datetime' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -1123,7 +1123,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a badly formatted datetime' do
-    tree = JCR.parse( '$trule= datetime' )
+    tree = JCR.parse( '$trule=: datetime' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-04-12T23.20.50.52Z", JCR::EvalConditions.new( mapping, nil ) )
@@ -1131,7 +1131,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a date string' do
-    tree = JCR.parse( '$trule= date' )
+    tree = JCR.parse( '$trule=: date' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-04-12", JCR::EvalConditions.new( mapping, nil ) )
@@ -1139,7 +1139,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number being passed as date' do
-    tree = JCR.parse( '$trule= date' )
+    tree = JCR.parse( '$trule=: date' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -1147,7 +1147,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a badly formatted date' do
-    tree = JCR.parse( '$trule= date' )
+    tree = JCR.parse( '$trule=: date' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "1985-14-12", JCR::EvalConditions.new( mapping, nil ) )
@@ -1155,7 +1155,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should pass a time string' do
-    tree = JCR.parse( '$trule= time' )
+    tree = JCR.parse( '$trule=: time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "23:20:50.52", JCR::EvalConditions.new( mapping, nil ) )
@@ -1163,7 +1163,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a number being passed as time' do
-    tree = JCR.parse( '$trule= time' )
+    tree = JCR.parse( '$trule=: time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], 2, JCR::EvalConditions.new( mapping, nil ) )
@@ -1171,7 +1171,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a badly formatted time with Z' do
-    tree = JCR.parse( '$trule= time' )
+    tree = JCR.parse( '$trule=: time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "23.20.50.52Z", JCR::EvalConditions.new( mapping, nil ) )
@@ -1179,7 +1179,7 @@ describe 'evaluate_value_rules' do
   end
 
   it 'should fail a badly formatted time with bad-data' do
-    tree = JCR.parse( '$trule= time' )
+    tree = JCR.parse( '$trule=: time' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], "24.20.50.52", JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/find_roots_spec.rb
+++ b/spec/find_roots_spec.rb
@@ -19,7 +19,7 @@ require_relative '../lib/jcr/find_roots'
 describe 'find_roots' do
 
   it 'should find no annotated roots with value rule' do
-    tree = JCR.parse( '$vrule= integer' )
+    tree = JCR.parse( '$vrule=: integer' )
     roots = JCR.find_roots( tree )
     expect( roots.length ).to eq( 0 )
   end
@@ -31,13 +31,13 @@ describe 'find_roots' do
   end
 
   it 'should find no annotated roots with array rule' do
-    tree = JCR.parse( '$vrule= [ integer @* ]' )
+    tree = JCR.parse( '$vrule=: [ integer @* ]' )
     roots = JCR.find_roots( tree )
     expect( roots.length ).to eq( 0 )
   end
 
   it 'should find an annotated rule' do
-    tree = JCR.parse( '$vrule= @{root} [ integer@* ]' )
+    tree = JCR.parse( '$vrule=: @{root} [ integer@* ]' )
     roots = JCR.find_roots( tree )
     expect( roots.length ).to eq( 1 )
     expect( roots[0] ).to be_an( JCR::Root )
@@ -48,7 +48,7 @@ describe 'find_roots' do
   end
 
   it 'should find an embedded annotated rule' do
-    tree = JCR.parse( '$vrule= [ @{root} integer @* ]' )
+    tree = JCR.parse( '$vrule=: [ @{root} integer @* ]' )
     roots = JCR.find_roots( tree )
     expect( roots.length ).to eq( 1 )
     expect( roots[0] ).to be_an( JCR::Root )
@@ -56,7 +56,7 @@ describe 'find_roots' do
   end
 
   it 'should find a sub embedded annotated rule' do
-    tree = JCR.parse( '$vrule= [ [ @{root} integer @* ] @* ]' )
+    tree = JCR.parse( '$vrule=: [ [ @{root} integer @* ] @* ]' )
     roots = JCR.find_roots( tree )
     expect( roots.length ).to eq( 1 )
     expect( roots[0] ).to be_an( JCR::Root )
@@ -65,7 +65,7 @@ describe 'find_roots' do
   end
 
   it 'should find two sub embedded annotated rule' do
-    tree = JCR.parse( '$vrule= [ @{root} [ @{root} integer @* ] @* ]' )
+    tree = JCR.parse( '$vrule=: [ @{root} [ @{root} integer @* ] @* ]' )
     roots = JCR.find_roots( tree )
     expect( roots.length ).to eq( 2 )
     expect( roots[0] ).to be_an( JCR::Root )
@@ -104,7 +104,7 @@ describe 'find_roots' do
 
 $width="width" : 0..1280
 $height="height" : 0..1024
-$ids=@{root} [ integer@* ]
+$ids=:@{root} [ integer@* ]
 
 EX7
     tree = JCR.parse( ex7 )

--- a/spec/jcr_spec.rb
+++ b/spec/jcr_spec.rb
@@ -51,7 +51,7 @@ EX
 # jcr-version 0.5
 
 [ $my_rule @* ]
-$my_rule = 0..2
+$my_rule =: 0..2
 
 EX
     ctx = JCR.ingest_ruleset( ex )
@@ -65,8 +65,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers = 0..2
-$my_strings = ( "foo" | "bar" )
+$my_integers =: 0..2
+$my_strings =: ( "foo" | "bar" )
 
 EX
     data = JSON.parse( '[ 1, 2, "foo", "bar" ]')
@@ -81,8 +81,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers = 0..2
-$my_strings = ( "foo" | "bar" )
+$my_integers =: 0..2
+$my_strings =: ( "foo" | "bar" )
 
 EX
     data = JSON.parse( '[ 1, 2, "foo", "bar" ]')
@@ -96,8 +96,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers = 0..2
-$my_strings = ( "foo" | "bar" )
+$my_integers =: 0..2
+$my_strings =: ( "foo" | "bar" )
 
 EX
     data1 = JSON.parse( '[ 1, 2, "foo", "bar" ]')
@@ -115,8 +115,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers = 0..2
-$my_strings = ( "foo" | "bar" )
+$my_integers =: 0..2
+$my_strings =: ( "foo" | "bar" )
 
 EX
     data1 = JSON.parse( '[ 1, 2, "foo", "bar" ]')
@@ -137,12 +137,12 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers=integer
-$my_strings=( "foo" | "bar" )
+$my_integers=:integer
+$my_strings=type ( "foo" | "bar" )
 
 EX
     ov = <<OV
-$my_integers=0..2
+$my_integers=:0..2
 OV
     data = JSON.parse( '[ 1, 2, "foo", "bar" ]')
     ctx = JCR::Context.new( ex )
@@ -157,12 +157,12 @@ OV
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers= integer
-$my_strings =( "foo" | "bar" )
+$my_integers=: integer
+$my_strings =:( "foo" | "bar" )
 
 EX
     ov = <<OV
-$my_integers =0..1
+$my_integers =:0..1
 OV
     data = JSON.parse( '[ 1, 2, "foo", "bar" ]')
     ctx = JCR::Context.new( ex )
@@ -177,12 +177,12 @@ OV
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers =integer
-$my_strings =( "foo" | "bar" )
+$my_integers =:integer
+$my_strings =:( "foo" | "bar" )
 
 EX
     ov = <<OV
-$my_integers=0..1
+$my_integers=:0..1
 OV
     data = JSON.parse( '[ 1, 2, "foo", "bar" ]')
     ctx = JCR::Context.new( ex )
@@ -199,9 +199,9 @@ OV
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$oroot =@{root} [ $my_strings @2, $my_integers @2 ]
-$my_integers=0..2
-$my_strings=( "foo" | "bar" )
+$oroot =:@{root} [ $my_strings @2, $my_integers @2 ]
+$my_integers=:0..2
+$my_strings=:( "foo" | "bar" )
 
 EX
     data = JSON.parse( '[ 1, 2, "foo", "bar" ]')
@@ -222,8 +222,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @1..2, $my_strings @2 ]
-$my_integers = 0..2
-$my_strings = ( "foo" | "bar" )
+$my_integers = :0..2
+$my_strings = :( "foo" | "bar" )
 
 EX
     my_eval_count = 0
@@ -247,8 +247,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers = 0..2
-$my_strings =( "foo" | "bar" )
+$my_integers = :0..2
+$my_strings =:( "foo" | "bar" )
 
 EX
     my_eval_count = 0
@@ -272,8 +272,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers= 0..2
-$my_strings= ( "foo" | "bar" )
+$my_integers= :0..2
+$my_strings= :( "foo" | "bar" )
 
 EX
     my_eval_count = 0
@@ -297,8 +297,8 @@ EX
 # jcr-version 0.5
 
 [ $my_integers @2, $my_strings @2 ]
-$my_integers =0..2
-$my_strings = ( "foo" | "bar" )
+$my_integers =:0..2
+$my_strings = :( "foo" | "bar" )
 
 EX
     my_eval_count = 0
@@ -324,9 +324,9 @@ EX
 [ $my_integers @2, $my_strings @2 ]
 
 ; this will be the rule we custom validate
-$my_integers = 0..4
+$my_integers = :0..4
 
-$my_strings = ( "foo" | "bar" )
+$my_strings = :( "foo" | "bar" )
 
 RULESET
 

--- a/spec/map_rule_names_spec.rb
+++ b/spec/map_rule_names_spec.rb
@@ -24,7 +24,7 @@ describe 'check_names' do
 $width = "width" : 0..1280
 $height = "height" : 0..1024
 
-$root = {
+$root = :{
     "Image" :{
         $width, $height, "Title" :string,
         "thumbnail" :{ $width, $height, "Url" :uri },
@@ -40,48 +40,48 @@ EX7
   end
 
   it 'should check rule names' do
-    tree = JCR.parse( '$vrule = integer ;; $mrule = "thing" :  $vrule' )
+    tree = JCR.parse( '$vrule = :integer ;; $mrule = "thing" :  $vrule' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
   end
 
   it 'should raise error with missing member rule' do
-    tree = JCR.parse( '$vrule = integer ;; $mrule = "thing" : $missingrule' )
+    tree = JCR.parse( '$vrule =: integer ;; $mrule = "thing" : $missingrule' )
     mapping = JCR.map_rule_names( tree )
     expect{ JCR.check_rule_target_names( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should find rule names in array' do
-    tree = JCR.parse( '$vrule1 = integer ;; $vrule2 = float $arule = [ $vrule1, $vrule2 ]' )
+    tree = JCR.parse( '$vrule1 =: integer ;; $vrule2 =: float $arule =: [ $vrule1, $vrule2 ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
   end
 
   it 'should find rule names in array of array' do
-    tree = JCR.parse( '$vrule1 = integer ;; $arule = [ $vrule1, [ $vrule1 ] ]' )
+    tree = JCR.parse( '$vrule1 =: integer ;; $arule =: [ $vrule1, [ $vrule1 ] ]' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
   end
 
   it 'should not find rule names in array of array' do
-    tree = JCR.parse( '$vrule1 = integer ;; $arule = [ $vrule1, [ $vrule2 ] ]' )
+    tree = JCR.parse( '$vrule1 =: integer ;; $arule =: [ $vrule1, [ $vrule2 ] ]' )
     mapping = JCR.map_rule_names( tree )
     expect{ JCR.check_rule_target_names( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should not find rule names in array of array in array' do
-    tree = JCR.parse( '$vrule1 = integer ;; $arule = [ $vrule1, [ $vrule1, [ $vrule2 ] ] ]' )
+    tree = JCR.parse( '$vrule1 =: integer ;; $arule =: [ $vrule1, [ $vrule1, [ $vrule2 ] ] ]' )
     mapping = JCR.map_rule_names( tree )
     expect{ JCR.check_rule_target_names( tree, mapping ) }.to raise_error RuntimeError
   end
 
   it 'should not allow rules with the same name' do
-    tree = JCR.parse( '$vrule = integer ;; $vrule = string' )
+    tree = JCR.parse( '$vrule =: integer ;; $vrule =: string' )
     expect{ JCR.map_rule_names( tree ) }.to raise_error RuntimeError
   end
 
   it 'should  allow rules with the same name' do
-    tree = JCR.parse( '$vrule = integer ;; $vrule = string' )
+    tree = JCR.parse( '$vrule =: integer ;; $vrule =: string' )
     mapping = JCR.map_rule_names( tree, true )
     JCR.check_rule_target_names( tree, mapping )
   end
@@ -98,7 +98,7 @@ EX7
 $width = "width" : 0..1280
 $height = "height" : 0..1024
 
-$root = {
+$root =: {
     "Image": {
         $width, $height, "Title" :string,
         "thumbnail" :{ $width, $height, "Url" :uri },
@@ -119,7 +119,7 @@ EX7
 $width = "width" : 0..1280
 $height = "height" : 0..1024
 
-$root = {
+$root =: {
     "Image" :{
         $width, $height, "Title" :string,
         "thumbnail": { $width, $height, "Url" :uri },

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -33,90 +33,101 @@ describe 'parser' do
 =end
 
   it 'should parse an ipv4 value defintion 1' do
-    tree = JCR.parse( '$trule = ipv4' )
+    tree = JCR.parse( '$trule = type ipv4' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
   end
 
   it 'should parse an ipv4 value defintion 2' do
-    tree = JCR.parse( '$trule = ipv4' )
+    tree = JCR.parse( '$trule = : ipv4' )
     expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
   end
 
   it 'should parse an ipv4 value defintion 3' do
-    tree = JCR.parse( '$trule = ipv4 ' )
+    tree = JCR.parse( '$trule = :ipv4' )
+    expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
+  end
+
+  it 'should parse an ipv4 value defintion 3' do
+    tree = JCR.parse( '$trule = :ipv4 ' )
     expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
   end
 
   it 'should parse an ipv6 value defintion 1' do
-    tree = JCR.parse( '$trule = ipv6' )
+    tree = JCR.parse( '$trule = type ipv6' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:ipv6]).to eq("ipv6")
   end
   it 'should parse an ipv6 value defintion 2' do
-    tree = JCR.parse( '$trule = ipv6' )
+    tree = JCR.parse( '$trule = : ipv6' )
     expect(tree[0][:rule][:primitive_rule][:ipv6]).to eq("ipv6")
   end
   it 'should parse an ipv6 value defintion 3' do
-    tree = JCR.parse( '$trule = ipv6 ' )
+    tree = JCR.parse( '$trule = type ipv6 ' )
     expect(tree[0][:rule][:primitive_rule][:ipv6]).to eq("ipv6")
   end
 
   it 'should parse an ipaddr value' do
-    tree = JCR.parse( '$trule = ipaddr' )
+    tree = JCR.parse( '$trule = type ipaddr' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:ipaddr]).to eq("ipaddr")
   end
 
   it 'should parse a string constant' do
-    tree = JCR.parse( '$trule = "a string constant"' )
+    tree = JCR.parse( '$trule = type "a string constant"' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
+  end
+
+  it 'should parse a string constant' do
+    tree = JCR.parse( '$trule = :"a string constant"' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
   end
 
   it 'should parse a string constant with extra space' do
-    tree = JCR.parse( '$trule = "a string constant"' )
+    tree = JCR.parse( '$trule = type "a string constant" ' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
   end
 
   it 'should parse a string' do
-    tree = JCR.parse( '$trule = string' )
+    tree = JCR.parse( '$trule = type string' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:string]).to eq("string")
   end
 
   it 'should parse a regex 1' do
-    tree = JCR.parse( '$trule = /a.regex.goes.here.*/' )
+    tree = JCR.parse( '$trule = type /a.regex.goes.here.*/' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex.goes.here.*")
   end
 
   it 'should parse a regex 2' do
-    tree = JCR.parse( '$trule = /a.regex\\.goes.here.*/' )
+    tree = JCR.parse( '$trule = type /a.regex\\.goes.here.*/' )
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex\\.goes.here.*")
   end
 
   it 'should parse a regex with a modifier' do
-    tree = JCR.parse( '$trule = /a.regex\\.goes.here.*/i' )
+    tree = JCR.parse( '$trule = type /a.regex\\.goes.here.*/i' )
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex\\.goes.here.*")
     expect(tree[0][:rule][:primitive_rule][:regex_modifiers]).to eq("i")
   end
 
   it 'should parse a regex with a multiple modifiers' do
-    tree = JCR.parse( '$trule = /a.regex\\.goes.here.*/ixs' )
+    tree = JCR.parse( '$trule = type /a.regex\\.goes.here.*/ixs' )
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex\\.goes.here.*")
     expect(tree[0][:rule][:primitive_rule][:regex_modifiers]).to eq("ixs")
   end
 
   it 'should parse a regex with a multiple modifiers and no extra space' do
-    tree = JCR.parse( '$trule = /a.regex\\.goes.here.*/ixs' )
+    tree = JCR.parse( '$trule = type /a.regex\\.goes.here.*/ixs' )
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex\\.goes.here.*")
     expect(tree[0][:rule][:primitive_rule][:regex_modifiers]).to eq("ixs")
   end
 
   it 'should parse a regex followed by a rule' do
-    tree = JCR.parse( '$trule = /a.regex.goes.here.*/$context= integer' )
+    tree = JCR.parse( '$trule = type /a.regex.goes.here.*/$context= :integer' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex.goes.here.*")
     expect(tree[0][:rule][:primitive_rule][:regex_modifiers]).to eq([])
@@ -124,7 +135,7 @@ describe 'parser' do
   end
 
   it 'should parse a regex with modifiers followed by a rule' do
-    tree = JCR.parse( '$trule = /a.regex.goes.here.*/si$des= integer' )
+    tree = JCR.parse( '$trule = type /a.regex.goes.here.*/si$des= :integer' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex.goes.here.*")
     expect(tree[0][:rule][:primitive_rule][:regex_modifiers]).to eq("si")
@@ -132,147 +143,147 @@ describe 'parser' do
   end
 
   it 'should parse a uri' do
-    tree = JCR.parse( '$trule = uri' )
+    tree = JCR.parse( '$trule = type uri' )
     expect(tree[0][:rule][:primitive_rule][:uri]).to eq("uri")
   end
 
   it 'should parse a uri template' do
-    tree = JCR.parse( '$trule = uri..{scheme}://example.com/{path}' )
+    tree = JCR.parse( '$trule = type uri..{scheme}://example.com/{path}' )
     expect(tree[0][:rule][:primitive_rule][:uri_template]).to eq("{scheme}://example.com/{path}")
   end
 
   it 'should parse a uri template 2' do
-    tree = JCR.parse( '$trule = uri..http://example.com/{path}' )
+    tree = JCR.parse( '$trule = type uri..http://example.com/{path}' )
     expect(tree[0][:rule][:primitive_rule][:uri_template]).to eq("http://example.com/{path}")
   end
 
   it 'should parse an any' do
-    tree = JCR.parse( '$trule = any' )
+    tree = JCR.parse( '$trule = type any' )
     expect(tree[0][:rule][:primitive_rule][:any]).to eq("any")
   end
 
   it 'should parse true' do
-    tree = JCR.parse( '$trule = true' )
+    tree = JCR.parse( '$trule = type true' )
     expect(tree[0][:rule][:primitive_rule][:true_v]).to eq("true")
   end
 
   it 'should parse false' do
-    tree = JCR.parse( '$trule = false' )
+    tree = JCR.parse( '$trule = type false' )
     expect(tree[0][:rule][:primitive_rule][:false_v]).to eq("false")
   end
 
   it 'should parse boolean' do
-    tree = JCR.parse( '$trule = boolean' )
+    tree = JCR.parse( '$trule = type boolean' )
     expect(tree[0][:rule][:primitive_rule][:boolean_v]).to eq("boolean")
   end
 
   it 'should parse null' do
-    tree = JCR.parse( '$trule = null' )
+    tree = JCR.parse( '$trule = type null' )
     expect(tree[0][:rule][:primitive_rule][:null]).to eq("null")
   end
 
   it 'should parse a integer value without a range' do
-    tree = JCR.parse( '$trule = integer' )
+    tree = JCR.parse( '$trule = type integer' )
     expect(tree[0][:rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
   it 'should parse a integer constant' do
-    tree = JCR.parse( '$trule = 2' )
+    tree = JCR.parse( '$trule = type 2' )
     expect(tree[0][:rule][:primitive_rule][:integer]).to eq("2")
   end
 
   it 'should parse a negative integer constant' do
-    tree = JCR.parse( '$trule = -2' )
+    tree = JCR.parse( '$trule = :-2' )
     expect(tree[0][:rule][:primitive_rule][:integer]).to eq("-2")
   end
 
   it 'should parse an integer full range' do
-    tree = JCR.parse( '$trule = 0..100' )
+    tree = JCR.parse( '$trule = :0..100' )
     expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
   it 'should parse a negative integer range to positive integer' do
-    tree = JCR.parse( '$trule = -1..100' )
+    tree = JCR.parse( '$trule = :-1..100' )
     expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("-1")
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
   it 'should parse a negative integer full range' do
-    tree = JCR.parse( '$trule = -100..-1' )
+    tree = JCR.parse( '$trule = :-100..-1' )
     expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("-100")
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-1")
   end
 
   it 'should parse an integer range with a min range' do
-    tree = JCR.parse( '$trule = 0..' )
+    tree = JCR.parse( '$trule = :0..' )
     expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
   end
 
   it 'should parse an integer rangge with a max range' do
-    tree = JCR.parse( '$trule = ..100' )
+    tree = JCR.parse( '$trule = :..100' )
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
   it 'should parse a negative integer range with a max range' do
-    tree = JCR.parse( '$trule = ..-100' )
+    tree = JCR.parse( '$trule = :..-100' )
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-100")
   end
 
   it 'should parse a sized int value without a range' do
-    tree = JCR.parse( '$trule = int32' )
+    tree = JCR.parse( '$trule = :int32' )
     expect(tree[0][:rule][:primitive_rule][:sized_int_v][:bits]).to eq("32")
   end
 
   it 'should parse a sized int value without a range' do
-    tree = JCR.parse( '$trule = uint32' )
+    tree = JCR.parse( '$trule = :uint32' )
     expect(tree[0][:rule][:primitive_rule][:sized_uint_v][:bits]).to eq("32")
   end
 
   it 'should parse a double value' do
-    tree = JCR.parse( '$trule = double' )
+    tree = JCR.parse( '$trule = :double' )
     expect(tree[0][:rule][:primitive_rule][:double_v]).to eq("double")
   end
 
   it 'should parse a float value' do
-    tree = JCR.parse( '$trule = float' )
+    tree = JCR.parse( '$trule = :float' )
     expect(tree[0][:rule][:primitive_rule][:float_v]).to eq("float")
   end
 
   it 'should parse a float constant' do
-    tree = JCR.parse( '$trule = 2.0' )
+    tree = JCR.parse( '$trule = :2.0' )
     expect(tree[0][:rule][:primitive_rule][:float]).to eq("2.0")
   end
 
   it 'should parse a negative float constant' do
-    tree = JCR.parse( '$trule = -2.0' )
+    tree = JCR.parse( '$trule = :-2.0' )
     expect(tree[0][:rule][:primitive_rule][:float]).to eq("-2.0")
   end
 
   it 'should parse a float range with a full range' do
-    tree = JCR.parse( '$trule = 0.0..100.0' )
+    tree = JCR.parse( '$trule = :0.0..100.0' )
     expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.0")
     expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.0")
   end
 
   it 'should parse a negative float range with a full range' do
-    tree = JCR.parse( '$trule = -100.0..-1.0' )
+    tree = JCR.parse( '$trule = :-100.0..-1.0' )
     expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("-100.0")
     expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("-1.0")
   end
 
   it 'should parse a float range with a min range' do
-    tree = JCR.parse( '$trule = 0.3939..' )
+    tree = JCR.parse( '$trule = :0.3939..' )
     expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.3939")
   end
 
   it 'should parse a float range with a max range' do
-    tree = JCR.parse( '$trule = ..100.003' )
+    tree = JCR.parse( '$trule = :..100.003' )
     expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.003")
   end
 
   it 'should parse an value with group 1' do
-    tree = JCR.parse( '$trule = ( 1.0 | 2 | true | "yes" | "Y" )' )
+    tree = JCR.parse( '$trule = :( 1.0 | 2 | true | "yes" | "Y" )' )
     expect(tree[0][:rule][:group_rule][0][:primitive_rule][:float]).to eq("1.0")
     expect(tree[0][:rule][:group_rule][1][:primitive_rule][:integer]).to eq("2")
     expect(tree[0][:rule][:group_rule][2][:primitive_rule][:true_v]).to eq("true")
@@ -281,7 +292,7 @@ describe 'parser' do
   end
 
   it 'should parse a value with group 2' do
-    tree = JCR.parse( '$trule = ( "no" | false | 1.0 | 2 | true | "yes" | "Y" )' )
+    tree = JCR.parse( '$trule = type ( "no" | false | 1.0 | 2 | true | "yes" | "Y" )' )
     expect(tree[0][:rule][:group_rule][0][:primitive_rule][:q_string]).to eq("no")
     expect(tree[0][:rule][:group_rule][1][:primitive_rule][:false_v]).to eq("false")
     expect(tree[0][:rule][:group_rule][2][:primitive_rule][:float]).to eq("1.0")
@@ -292,7 +303,7 @@ describe 'parser' do
   end
 
   it 'should parse a value with group 3' do
-    tree = JCR.parse( '$trule = ( null | "no" | false | 1.0 | 2 | true | "yes" | "Y" )' )
+    tree = JCR.parse( '$trule = :( null | "no" | false | 1.0 | 2 | true | "yes" | "Y" )' )
     expect(tree[0][:rule][:group_rule][0][:primitive_rule][:null]).to eq("null")
     expect(tree[0][:rule][:group_rule][1][:primitive_rule][:q_string]).to eq("no")
     expect(tree[0][:rule][:group_rule][2][:primitive_rule][:false_v]).to eq("false")
@@ -304,7 +315,7 @@ describe 'parser' do
   end
 
   it 'should parse two rules' do
-    tree = JCR.parse( '$vrule = integer $mrule ="thing": $vrule' )
+    tree = JCR.parse( '$vrule = :integer $mrule ="thing": $vrule' )
     expect(tree[0][:rule][:rule_name]).to eq("vrule")
     expect(tree[1][:rule][:rule_name]).to eq("mrule")
   end
@@ -416,26 +427,31 @@ describe 'parser' do
   end
 
   it 'should parse an empty object rule' do
+    tree = JCR.parse( '$trule = :{ }' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+  end
+
+  it 'should parse an empty object rule without type designator' do
     tree = JCR.parse( '$trule = { }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an object rule with rule names' do
-    tree = JCR.parse( '$trule = { $my_rule1, $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ $my_rule1, $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an object rule with rule names or`ed' do
-    tree = JCR.parse( '$trule = { $my_rule1 | $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ $my_rule1 | $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an object rule with embeded member rules with names 1' do
-    tree = JCR.parse( '$trule = { "thing" : $my_value_rule, $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ "thing" : $my_value_rule, $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:target_rule_name][:rule_name]).to eq("my_value_rule")
@@ -443,7 +459,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with embeded member rules with names or`ed`' do
-    tree = JCR.parse( '$trule = { "thing" : $my_value_rule| $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ "thing" : $my_value_rule| $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:target_rule_name][:rule_name]).to eq("my_value_rule")
@@ -451,7 +467,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with embeded member rules with value rule 1' do
-    tree = JCR.parse( '$trule = { "thing" : ..100.003, $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ "thing" : ..100.003, $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
@@ -459,7 +475,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule name, embeded member rules with value, rule name' do
-    tree = JCR.parse( '$trule = { $my_rule1, "thing" : ..100.003, $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ $my_rule1, "thing" : ..100.003, $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:member_rule][:member_name][:q_string]).to eq("thing")
@@ -486,7 +502,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with embeded member rules with value rule ored' do
-    tree = JCR.parse( '$trule = { "thing" : ..100.003| $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ "thing" : ..100.003| $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
@@ -494,7 +510,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with embeded member rules with value rule spelled out 1' do
-    tree = JCR.parse( '$trule = { "thing" : ..100.003, $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ "thing" : ..100.003, $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:primitive_rule][:float_max]).to eq("100.003")
@@ -502,7 +518,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with optionality 1' do
-    tree = JCR.parse( '$trule = { $my_rule1, $my_rule2 @..1 }' )
+    tree = JCR.parse( '$trule = type { $my_rule1, $my_rule2 @..1 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
@@ -511,7 +527,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with optional repetition' do
-    tree = JCR.parse( '$trule = { $my_rule1, $my_rule2 @? }' )
+    tree = JCR.parse( '$trule = type { $my_rule1, $my_rule2 @? }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
@@ -519,7 +535,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with zero or many repetition' do
-    tree = JCR.parse( '$trule = { $my_rule1, $my_rule2 @* }' )
+    tree = JCR.parse( '$trule = :{ $my_rule1, $my_rule2 @* }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
@@ -527,7 +543,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with zero or many repetition' do
-    tree = JCR.parse( '$trule = { $my_rule1, $my_rule2 @+}' )
+    tree = JCR.parse( '$trule = :{ $my_rule1, $my_rule2 @+}' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
@@ -535,7 +551,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with 2 repetition' do
-    tree = JCR.parse( '$trule = { $my_rule1, $my_rule2 @2}' )
+    tree = JCR.parse( '$trule = :{ $my_rule1, $my_rule2 @2}' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
@@ -543,7 +559,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with optionality 2' do
-    tree = JCR.parse( '$trule = { $my_rule1 @..1, $my_rule2 @..1 }' )
+    tree = JCR.parse( '$trule = :{ $my_rule1 @..1, $my_rule2 @..1 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq(nil)
@@ -554,7 +570,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with optionality with or' do
-    tree = JCR.parse( '$trule = { $my_rule1@..1| $my_rule2 @..1}' )
+    tree = JCR.parse( '$trule = :{ $my_rule1@..1| $my_rule2 @..1}' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq(nil)
@@ -565,7 +581,7 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with embeded member rules with value rule with optionality 1' do
-    tree = JCR.parse( '$trule = { "thing" : ..100.003 @0..1, $my_rule2 }' )
+    tree = JCR.parse( '$trule = :{ "thing" : ..100.003 @0..1, $my_rule2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:member_rule][:member_name][:q_string]).to eq("thing")
     expect(tree[0][:rule][:object_rule][0][:repetition_min]).to eq("0")
@@ -575,40 +591,45 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with rule names with optionality for any rules' do
-    tree = JCR.parse( '$trule = { $my_rule1, $my_rule2 @1..2 }' )
+    tree = JCR.parse( '$trule = :{ $my_rule1, $my_rule2 @1..2 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:object_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:object_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an empty array rule' do
+    tree = JCR.parse( '$trule = :[ ]' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+  end
+
+  it 'should parse an empty array rule without a type designator' do
     tree = JCR.parse( '$trule = [ ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an array rule with rule names 1' do
-    tree = JCR.parse( '$trule = [ $my_rule1, $my_rule2 ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1, $my_rule2 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an array rule with preceding colon' do
-    tree = JCR.parse( '$trule = [ $my_rule1, $my_rule2 ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1, $my_rule2 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an array rule with rule names ored' do
-    tree = JCR.parse( '$trule = [ $my_rule1| $my_rule2 ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1| $my_rule2 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an array rule with rule names and repetition' do
-    tree = JCR.parse( '$trule = [ $my_rule1 @1..2, $my_rule2 @1.., $my_rule3 @..3 ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 @1..2, $my_rule2 @1.., $my_rule3 @..3 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][0][:repetition_min]).to eq("1")
@@ -621,11 +642,11 @@ describe 'parser' do
   end
 
   it 'should not parse an array rule with rule names ored for one and repetition' do
-    expect{ JCR.parse( '$trule = [ $my_rule1 @1..2, $my_rule2 @1..| $my_rule3 @..3 ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :[ $my_rule1 @1..2, $my_rule2 @1..| $my_rule3 @..3 ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should parse an array rule with rule names ored and repetition' do
-    tree = JCR.parse( '$trule = [ $my_rule1 @1..2| $my_rule2 @1..| $my_rule3 @..3]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 @1..2| $my_rule2 @1..| $my_rule3 @..3]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][0][:repetition_min]).to eq("1")
@@ -638,7 +659,7 @@ describe 'parser' do
   end
 
   it 'should parse an array rule with rule names and short repetition' do
-    tree = JCR.parse( '$trule = [ $my_rule1 @*, $my_rule2 @+, $my_rule3 @?, $my_rule4 @4 ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 @*, $my_rule2 @+, $my_rule3 @?, $my_rule4 @4 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][0][:repetition_min]).to eq(nil)
@@ -652,43 +673,43 @@ describe 'parser' do
   end
 
   it 'should not parse an array rule with rule names ored for one and short repetition' do
-    expect{ JCR.parse( '$trule = [ $my_rule1 @*, $my_rule2 @+| $my_rule3@?,$my_rule4@4 ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :[ $my_rule1 @*, $my_rule2 @+| $my_rule3@?,$my_rule4@4 ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should parse an array rule with an object rule' do
-    tree = JCR.parse( '$trule = [ $my_rule1, { $my_rule2 } ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1, { $my_rule2 } ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:array_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
     expect(tree[0][:rule][:array_rule][1][:object_rule][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
   it 'should parse an array rule with an object rule and value rule' do
-    tree = JCR.parse( '$trule = [ integer , { $my_rule2 } ]' )
+    tree = JCR.parse( '$trule = :[ integer , { $my_rule2 } ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an array rule with a rulename and an array rule' do
-    tree = JCR.parse( '$trule = [ $my_rule1 , [ $my_rule2 ] ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 , [ $my_rule2 ] ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an array rule with a rulename and an array rule with an object rule and value rule' do
-    tree = JCR.parse( '$trule = [ $my_rule1 , [ integer, { $my_rule2 } ] ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 , [ integer, { $my_rule2 } ] ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an array rule with a rulename and an array rule with an object rule and value rule all ored' do
-    tree = JCR.parse( '$trule = [ $my_rule1 | [ integer | { $my_rule2 } ] ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 | [ integer | { $my_rule2 } ] ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an array rule with a rulename and a group rule' do
-    tree = JCR.parse( '$trule = [ $my_rule1 | ( integer | { $my_rule2 } ) ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 | ( integer | { $my_rule2 } ) ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an array rule with a rulename and a group rule with count' do
-    tree = JCR.parse( '$trule = [ $my_rule1 | ( integer | { $my_rule2 } )@1..2 ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 | ( integer | { $my_rule2 } )@1..2 ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
@@ -763,22 +784,22 @@ describe 'parser' do
   end
 
   it 'should parse an object rule with a group rule and a rulename' do
-    tree = JCR.parse( '$trule = { ( $my_rule1, $my_rule2 ), $my_rule3 }' )
+    tree = JCR.parse( '$trule = :{ ( $my_rule1, $my_rule2 ), $my_rule3 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an object rule with an optional group rule and a rulename' do
-    tree = JCR.parse( '$trule = { ( $my_rule1, $my_rule2 )@0..1, $my_rule3 }' )
+    tree = JCR.parse( '$trule = :{ ( $my_rule1, $my_rule2 )@0..1, $my_rule3 }' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse an array rule with rule names and repitition and a group rule' do
-    tree = JCR.parse( '$trule = [ $my_rule1 @1..2, ( $my_rule2, $my_rule3 ) ]' )
+    tree = JCR.parse( '$trule = :[ $my_rule1 @1..2, ( $my_rule2, $my_rule3 ) ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse a value rule with a comment' do
-    tree = JCR.parse( '$trule = /.*/ ;\;;' )
+    tree = JCR.parse( '$trule = :/.*/ ;\;;' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
@@ -788,7 +809,7 @@ describe 'parser' do
   end
 
   it 'should parse two rules separated by a comment' do
-    tree = JCR.parse( '$trule1 = /.*/ ;; $trule2 = /.*/ : $target_rule' )
+    tree = JCR.parse( '$trule1 = :/.*/ ;; $trule2 = /.*/ : $target_rule' )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
     expect(tree[1][:rule][:rule_name]).to eq("trule2")
   end
@@ -810,7 +831,7 @@ describe 'parser' do
   end
 
   it 'should parse a top value rule and another rules separated by a comment' do
-    tree = JCR.parse( '[ $target_rule @* ] ;; $trule = /.*/' )
+    tree = JCR.parse( '[ $target_rule @* ] ;; $trule = :/.*/' )
   end
 
   it 'should parse multiple comments before any directives' do
@@ -828,7 +849,7 @@ EX
 
   it 'should parse two rules separated by multiple comment' do
     ex = <<EX
-$trule1= /.*/
+$trule1= type /.*/
 ;comment 1
 ;comment 2
 ;comment 3
@@ -845,7 +866,7 @@ EX
 $trule1
 	;comment 1
 	;comment 2
-	=
+	=:
 /.*/
 $trule2 = /.*/: $target_rule
 EX
@@ -857,7 +878,7 @@ EX
   it 'should parse rules, directives, comments and bottom rules' do
     ex = <<EX
 [ $trule1 ]
-$trule1 = /.*/
+$trule1 = type /.*/
 ;comment 1
 ;comment 2
 ;comment 3
@@ -870,7 +891,7 @@ EX
 
   it 'should parse an array rule with rule names and repitition and a group rule with newlines' do
     ex1 = <<EX1
-$trule=[
+$trule=:[
   $my_rule1 @1..2,
   ( $my_rule2, $my_rule3 )
 ]
@@ -881,7 +902,7 @@ EX1
 
   it 'should parse an array rule with rule names and repitition and a group rule with a trailing comment' do
     ex2 = <<EX2
-$trule =[ ;comment 1
+$trule =:[ ;comment 1
   $my_rule1 @1..2, ;comment 2
   ( $my_rule2, $my_rule3 ) ;comment 3
 ] ;comment 4
@@ -892,7 +913,7 @@ EX2
 
   it 'should parse group rules and value groups' do
     ex2a = <<EX2A
-$trule =[ ;comment 1
+$trule =:[ ;comment 1
   $my_rule1 @1..2, ;comment 2
   ( string | integer ),
   ( $my_rule2 | $my_rule3 ) ;comment 3
@@ -904,7 +925,7 @@ EX2A
 
   it 'should parse group rules and value groups with embedded comments' do
     ex2a = <<EX2A
-$trule =[ ;comment 1
+$trule =:[ ;comment 1
   $my_rule1 ;one or two; @1..2, ;comment 2
   ;can be string or integer; ( string | integer ),
   ( $my_rule2 | ;my third rule; $my_rule3 ) ;comment 3
@@ -916,7 +937,7 @@ EX2A
 
   it 'should parse group rules and value union that are ored' do
     ex2b = <<EX2B
-$trule =[ ;comment 1
+$trule =:[ ;comment 1
   $my_rule1 @1..2| ;comment 2
   ( string | integer ) |
   ( $my_rule2 , $my_rule3 ) ;comment 3
@@ -928,7 +949,7 @@ EX2B
 
   it 'should parse multiple commented rules' do
     ex3 = <<EX3
-$trule= [ ;comment 1
+$trule= type [ ;comment 1
   $my_rule1 @1..2, ;comment 2
   ( $my_rule2, $my_rule3 ) ;comment 3
 ] ;comment 4
@@ -943,7 +964,7 @@ EX3
     ex4 = <<EX4
 # ruleset-id http://arin.net/JCRexamples
 # import http://arin.net/otherexamples
-$trule = [ ;comment 1
+$trule = :[ ;comment 1
   $my_rule1 @1..2, ;comment 2
   ( $my_rule2, $my_rule3 ) ;comment 3
 ] ;comment 4
@@ -959,7 +980,7 @@ EX4
 # jcr-version 4.0
 # ruleset-id net.arin.eng
 # import http://arin.net/otherexamples as otherrules
-$trule = [ ;comment 1
+$trule = :[ ;comment 1
   $my_rule1 @1..2, ;comment 2
   ( $my_rule2, $my_rule3 ) ;comment 3
 ] ;comment 4
@@ -1039,7 +1060,7 @@ EX5e
 
   it 'should parse ex1 from I-D' do
     ex6 = <<EX6
-$root = [
+$root =: [
     {
         "precision" : string,
         "Latitude" : float,
@@ -1061,7 +1082,7 @@ EX6
 $width = "width" : 0..1280
 $height = "height" : 0..1024
 
-$root = {
+$root =: {
     "Image" : {
         $width, $height, "Title" :string,
         "thumbnail":  { $width, $height, "Url" :uri },
@@ -1075,7 +1096,7 @@ EX7
 
   it 'should parse ex3 from I-D' do
     ex8 = <<EX8
-$nameserver = {
+$nameserver = :{
 
      ; the host name of the name server
      "name" : fqdn,
@@ -1095,7 +1116,7 @@ EX8
     ex9 = <<EX9
 $any_member = /.*/ : any
 
-$object_of_anything = { $any_member@* }
+$object_of_anything =: { $any_member@* }
 EX9
     tree = JCR.parse( ex9 )
     expect(tree[0][:rule][:rule_name]).to eq("any_member")
@@ -1103,7 +1124,7 @@ EX9
 
   it 'should parse ex5 from I-D' do
     ex10 = <<EX10
-$object_of_anything = { /.*/:any@* }
+$object_of_anything = :{ /.*/:any@* }
 EX10
     tree = JCR.parse( ex10 )
     expect(tree[0][:rule][:rule_name]).to eq("object_of_anything")
@@ -1111,9 +1132,9 @@ EX10
 
   it 'should parse ex6 from I-D' do
     ex11 = <<EX11
-$any_value = any
+$any_value =: any
 
-$array_of_any = [ $any_value@* ]
+$array_of_any = :[ $any_value@* ]
 EX11
     tree = JCR.parse( ex11 )
     expect(tree[0][:rule][:rule_name]).to eq("any_value")
@@ -1121,7 +1142,7 @@ EX11
 
   it 'should parse ex7 from I-D' do
     ex12 = <<EX12
-$array_of_any = [ any@.. ]
+$array_of_any = :[ any@.. ]
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[0][:rule][:rule_name]).to eq("array_of_any")
@@ -1129,9 +1150,9 @@ EX12
 
   it 'should parse groups of values with groups' do
     ex12 = <<EX12
-$encodings = ( "base32" | "base64" )
-$more_encodings = ( "base32hex" | "base64url" | "base16" )
-$all_encodings = ( $encodings | $more_encodings )
+$encodings = :( "base32" | "base64" )
+$more_encodings = :( "base32hex" | "base64url" | "base16" )
+$all_encodings = :( $encodings | $more_encodings )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[0][:rule][:rule_name]).to eq("encodings")
@@ -1139,9 +1160,9 @@ EX12
 
   it 'should parse groups of values with groups and values with groups with rules' do
     ex12 = <<EX12
-$encodings = ( "base32" | "base64" )
-$more_encodings = ( "base32hex" | "base64url" | "base16" )
-$all_encodings = ( $encodings | $more_encodings )
+$encodings = :( "base32" | "base64" )
+$more_encodings = :( "base32hex" | "base64url" | "base16" )
+$all_encodings = :( $encodings | $more_encodings )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[0][:rule][:rule_name]).to eq("encodings")
@@ -1149,7 +1170,7 @@ EX12
 
   it 'should parse groups of values' do
     ex12 = <<EX12
-$encodings = ( "base32" | "base64" )
+$encodings = :( "base32" | "base64" )
 $more_encodings = ( "base32hex" | "base64url" | "base16" )
 $all_encodings = ( $encodings | $more_encodings )
 EX12
@@ -1159,9 +1180,9 @@ EX12
 
   it 'should parse groups of values and rulenames' do
     ex12 = <<EX12
-$encodings = ( "base32" | "base64" )
-$more_encodings = ( "base32hex" | "base64url" | "base16" )
-$all_encodings = ( "rot13" | $encodings | $more_encodings )
+$encodings = type ( "base32" | "base64" )
+$more_encodings = type ( "base32hex" | "base64url" | "base16" )
+$all_encodings = type ( "rot13" | $encodings | $more_encodings )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[0][:rule][:rule_name]).to eq("encodings")
@@ -1170,9 +1191,9 @@ EX12
   it 'should parse groups of values with namespaced rule names' do
     ex12 = <<EX12
 # import http://ietf.org/rfcXXXX.JCR as rfcXXXX
-$encodings = ( "base32" | "base64" )
-$more_encodings = ( "base32hex" | "base64url" | "base16" )
-$all_encodings = ( $rfcXXXX.encodings | $more_encodings )
+$encodings = :( "base32" | "base64" )
+$more_encodings = :( "base32hex" | "base64url" | "base16" )
+$all_encodings = :( $rfcXXXX.encodings | $more_encodings )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[3][:rule][:rule_name]).to eq("all_encodings")
@@ -1184,8 +1205,8 @@ EX12
     ex12 = <<EX12
 # import http://ietf.org/rfcXXXX.JCR as rfcXXXX
 $encodings = ( "base32" | "base64" )
-$more_encodings = ( "base32hex" | "base64url" | "base16" )
-$all_encodings = ( $more_encodings | $rfcXXXX.encodings )
+$more_encodings = :( "base32hex" | "base64url" | "base16" )
+$all_encodings = :( $more_encodings | $rfcXXXX.encodings )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[3][:rule][:rule_name]).to eq("all_encodings")
@@ -1194,7 +1215,7 @@ EX12
 
   it 'should parse groups as groups' do
     ex12 = <<EX12
-$encodings = ( "base32" | "base64" | integer | /^.{5,10}/ | ipv4 | ipv6 | fqdn )
+$encodings = :( "base32" | "base64" | integer | /^.{5,10}/ | ipv4 | ipv6 | fqdn )
 EX12
     tree = JCR.parse( ex12 )
     expect(tree[0][:rule][:rule_name]).to eq("encodings")
@@ -1217,55 +1238,55 @@ EX12
   end
 
   it 'should error with object with group of value OR value' do
-    expect{ JCR.parse( '$arule = { ( "m2" :integer | :integer ) }' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$arule = :{ ( "m2" :integer | :integer ) }' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with object with group of value OR array' do
-    expect{ JCR.parse( '$arule = { ( "m2" :integer | [ integer ] ) }' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$arule = :{ ( "m2" :integer | [ integer ] ) }' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with object with group of value OR object' do
-    expect{ JCR.parse( '$arule = { ( "m2" :integer | { "m1" :integer } ) }' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$arule = :{ ( "m2" :integer | { "m1" :integer } ) }' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with object with two groups of members and values 2' do
-    expect{ JCR.parse( '$rule = { ( "m1" :integer | :float ), ( "m3" :string, "m4" :string ) }' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$rule = :{ ( "m1" :integer | :float ), ( "m3" :string, "m4" :string ) }' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with object with two groups of members and values 1' do
-    expect{ JCR.parse( '$rule = { ( "m1" :integer | "m2" :float ), ( "m3" :string, string ) }' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$rule = :{ ( "m1" :integer | "m2" :float ), ( "m3" :string, string ) }' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with object with group with member and value' do
-    expect{ JCR.parse( '$rule = { ( "thing" :integer | integer ) }' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$rule = :{ ( "thing" :integer | integer ) }' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with object with group with member and value' do
-    expect{ JCR.parse( '$rule = { ( "thing" :integer | integer ) }' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$rule = :{ ( "thing" :integer | integer ) }' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with array with group of value OR with group with member' do
-    expect{ JCR.parse( '$trule = any ;; $rule = [ ( integer | ( ipv4 | "thing" : $trule ) ) ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :any ;; $rule = :[ ( integer | ( ipv4 | "thing" : $trule ) ) ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with array with group of OR values and array with group of values and member' do
-    expect{ JCR.parse( '$trule = any ;; $rule = [ ( integer | float ) ] ;; $rule2 = [ ( ipv4 , "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :any ;; $rule = :[ ( integer | float ) ] ;; $rule2 = :[ ( ipv4 , "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with array with value and group of one value and one member' do
-    expect{ JCR.parse( '$trule = any ;; $rule = [ string, ( integer, "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :any ;; $rule = :[ string, ( integer, "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with array with group of one value and one member' do
-    expect{ JCR.parse( '$trule = any ;; $rule = [ ( integer, "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :any ;; $rule = :[ ( integer, "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with array with group of one member' do
-    expect{ JCR.parse( '$trule = any ;; $rule = [ ( "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :any ;; $rule = :[ ( "thing" : $trule ) ]' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with value with group of value OR group with member' do
-    expect{ JCR.parse( '$trule = :any ;; $rule = ( integer | ( ipv4 | "thing" : $trule ) ) ' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$trule = :any ;; $rule = :( integer | ( ipv4 | "thing" : $trule ) ) ' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should error with value with group of ORed and ANDED values' do
@@ -1273,11 +1294,15 @@ EX12
   end
 
   it 'should error with integer or float with no range' do
-    expect{ JCR.parse( '$my_int = ..' ) }.to raise_error Parslet::ParseFailed
+    expect{ JCR.parse( '$my_int = :..' ) }.to raise_error Parslet::ParseFailed
   end
 
   it 'should parse value rule with {not} annotation directive' do
-    tree = JCR.parse( '$my_int = @{not} 2' )
+    tree = JCR.parse( '$my_int = type @{not} 2' )
+  end
+
+  it 'should parse value rule with {not} annotation directive' do
+    tree = JCR.parse( '$my_int = : @{not} 2' )
   end
 
   it 'should parse member rule with {not} annotation directive' do
@@ -1285,31 +1310,31 @@ EX12
   end
 
   it 'should parse object rule with {not} annotation directive' do
-    tree = JCR.parse( '$my_rule = @{not} { "count" :integer }' )
+    tree = JCR.parse( '$my_rule = : @{not} { "count" :integer }' )
   end
 
   it 'should parse object rule with {not} annotation directive' do
-    tree = JCR.parse( '$my_rule = @{root} @{not} { "count" :integer }' )
+    tree = JCR.parse( '$my_rule =: @{root} @{not} { "count" :integer }' )
   end
 
   it 'should parse array rule with {not} annotation directive' do
-    tree = JCR.parse( '$my_rule = @{not} [ integer@* ]' )
+    tree = JCR.parse( '$my_rule =: @{not} [ integer@* ]' )
   end
 
   it 'should parse array rule with unordered directive' do
-    tree = JCR.parse( '$my_rule = @{unordered} [ integer@* ]' )
+    tree = JCR.parse( '$my_rule =: @{unordered} [ integer@* ]' )
   end
 
   it 'should parse array rule with root directive' do
-    tree = JCR.parse( '$my_rule = @{root} [ integer@* ]' )
+    tree = JCR.parse( '$my_rule =: @{root} [ integer@* ]' )
   end
 
   it 'should parse array rule with unordered directive' do
-    tree = JCR.parse( '$my_rule = @{unordered} @{not} [ integer@* ]' )
+    tree = JCR.parse( '$my_rule =: @{unordered} @{not} [ integer@* ]' )
   end
 
   it 'should parse array rule with unordered directive' do
-    tree = JCR.parse( '$my_rule = @{not} @{unordered} [ integer@* ]' )
+    tree = JCR.parse( '$my_rule =: @{not} @{unordered} [ integer@* ]' )
   end
 
   it 'should parse group rule with {not} annotation directive' do
@@ -1317,11 +1342,11 @@ EX12
   end
 
   it 'should parse array rule with {not} annotation directive on value rule' do
-    tree = JCR.parse( '$my_rule = [ @{not} integer @* ]' )
+    tree = JCR.parse( '$my_rule = :[ @{not} integer @* ]' )
   end
 
   it 'should parse array rule with {not} annotation directive on target rule' do
-    JCR.parse( '$my_rule = [ @{not} $target_rule ]' )
+    JCR.parse( '$my_rule = :[ @{not} $target_rule ]' )
   end
 
   it 'should parse a group rule with a rulename only with {not} annotation' do
@@ -1330,19 +1355,19 @@ EX12
   end
 
   it 'should parse an unknown annotation' do
-    tree = JCR.parse( '$my_int = @{assert $ % 3 == 0} 2' )
+    tree = JCR.parse( '$my_int =: @{assert $ % 3 == 0} 2' )
     expect(tree[0][:rule][:rule_name]).to eq("my_int")
   end
 
   it 'should parse an unknown annotation with comments, q_string and regexs' do
-    tree = JCR.parse( '$my_int = @{assert $name == /p\d{1,5}/ && ; Must allow } and { in comments
+    tree = JCR.parse( '$my_int =: @{assert $name == /p\d{1,5}/ && ; Must allow } and { in comments
                           $when == "} with {"
                           } 2' )
     expect(tree[0][:rule][:rule_name]).to eq("my_int")
   end
 
   it 'should parse an array with a literal number' do
-    JCR.parse( '$v = 1' )
+    JCR.parse( '$v =: 1' )
   end
 
   it 'should parse an array with a literal number' do


### PR DESCRIPTION
In this version I've gone for the syntaxes:

    $rule = type "my_string"
    $r2 = : "other string"
    $r3 = :{ ... }

While editing the tests I found that putting the `=` and `:` together to make `=:` works quite well as a clear, concise and inconspicuous way of using the notations.  i.e. you get:

    $rule =: "my_string"
    $r3 =: { ... }

A key thing to note is that `$r = (...)` is a group that can be put in arrays and objects, whereas `$r =: (...)` is a type choice that can be used as a type.  While I think this is an important distinction, it's also a subtle one.  I've therefore allowed objects and arrays not to have the type designator.  So you can do both:

    $r =: { ... }
    $r = { ... }

It maybe appropriate to only allow the second form as arrays and objects are similar to groups, and having them consistent would be a good thing.  Let me know.

Naturally, if you'd rather go a different way, don't merge this :-)
