### PR TITLE
Change tests to reflect jcr-version is 0.7

### DIFF
--- a/spec/jcr_spec.rb
+++ b/spec/jcr_spec.rb
@@ -22,7 +22,7 @@ describe 'jcr' do
   it 'should pass default rule' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ integer@* ]
 
@@ -35,7 +35,7 @@ EX
   it 'should fail default rule' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ string@* ]
 
@@ -48,7 +48,7 @@ EX
   it 'should pass default rule referencing another rule' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_rule @* ]
 $my_rule =: 0..2
@@ -62,7 +62,7 @@ EX
   it 'should pass default rule referencing two rules with JSON' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers =: 0..2
@@ -78,7 +78,7 @@ EX
   it 'should initialize a context and evaluate JSON' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers =: 0..2
@@ -93,7 +93,7 @@ EX
   it 'should initialize a context and evaluate two JSONs' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers =: 0..2
@@ -112,7 +112,7 @@ EX
   it 'should initialize a context and evaluate two JSONs and fail a third' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers =: 0..2
@@ -134,7 +134,7 @@ EX
   it 'should pass default rule referencing two rules with JSON and override' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers=:integer
@@ -154,7 +154,7 @@ OV
   it 'should fail default rule referencing two rules with JSON and override!' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers=: integer
@@ -174,7 +174,7 @@ OV
   it 'should fail default rule referencing two rules with JSON and override!' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers =:integer
@@ -196,7 +196,7 @@ OV
   it 'should evaluate JSON against multiple roots' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $oroot =:@{root} [ $my_strings @2, $my_integers @2 ]
@@ -219,7 +219,7 @@ EX
   it 'should callback eval_true once' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @1..2, $my_strings @2 ]
 $my_integers = :0..2
@@ -244,7 +244,7 @@ EX
   it 'should callback eval_true twice' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers = :0..2
@@ -269,7 +269,7 @@ EX
   it 'should callback eval_false once' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers= :0..2
@@ -294,7 +294,7 @@ EX
   it 'should callback eval_false twice by changing return value' do
     ex = <<EX
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 $my_integers =:0..2
@@ -319,7 +319,7 @@ EX
   it 'should use callback to evaluate even numbers' do
     ruleset = <<RULESET
 # ruleset-id rfcXXXX
-# jcr-version 0.5
+# jcr-version 0.7
 
 [ $my_integers @2, $my_strings @2 ]
 

--- a/spec/process_directives_spec.rb
+++ b/spec/process_directives_spec.rb
@@ -23,7 +23,7 @@ describe 'process_directives' do
 # ruleset-id rfcXXXX
 ; a comment
 ; another comment
-# jcr-version 0.5
+# jcr-version 0.7
 ; yet another comment
 EX
     ctx = JCR::Context.new
@@ -32,12 +32,12 @@ EX
     expect( ctx.id ).to eq("rfcXXXX")
   end
 
-  it 'should process jcr-version 0.5' do
+  it 'should process jcr-version 0.7' do
     ex = <<EX
 # ruleset-id rfcXXXX
 ; a comment
 ; another comment
-# jcr-version 0.5
+# jcr-version 0.7
 ; yet another comment
 EX
     ctx = JCR::Context.new
@@ -45,7 +45,7 @@ EX
     JCR.process_directives( ctx )
   end
 
-  it 'should fail to process jcr-version 0.5' do
+  it 'should fail to process jcr-version 0.4' do
     ex = <<EX
 # ruleset-id rfcXXXX
 # jcr-version 0.4


### PR DESCRIPTION
You may have forgotten to push this version, but in case it helps, hears the fixes to the tests to take account of the jcr-version being looked for is 0.7