### PR TITLE
Made directive spacing conditional on context

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -2,24 +2,28 @@ jcr              = *( sp-cmt / directive / root-rule / rule )
 
 sp-cmt           = spaces / comment
 spaces           = 1*( WSP / CR / LF )
+DSPs             = ; Directive spaces
+                   1*WSP /     ; When in one-line directive
+                   1*sp-cmt   ; When in muti-line directive
 comment          = ";" *comment-char comment-end-char
 comment-char     = HTAB / %x20-10FFFF
                    ; Any char other than CR / LF
 comment-end-char = CR / LF
 
 directive        = "#" (one-line-directive / multi-line-directive)
-one-line-directive = [ spaces ] 
+one-line-directive = [ DSPs ] 
                    (directive-def / one-line-tbd-directive-d) *WSP eol
 multi-line-directive = "{" *sp-cmt
                    (directive-def / multi-line-tbd-directive-d) *sp-cmt "}"
 directive-def    = jcr-version-d / ruleset-id-d / import-d
-jcr-version-d    = jcr-version-kw spaces major-version "." minor-version *(spaces extension-id)
+jcr-version-d    = jcr-version-kw DSPs major-version "." minor-version
+                   *( DSPs "+" [ DSPs ] extension-id )
 major-version    = non-neg-integer
 minor-version    = non-neg-integer
 extension-id     = ALPHA *not-space
-ruleset-id-d     = ruleset-id-kw spaces ruleset-id
-import-d         = import-kw spaces ruleset-id
-                   [ spaces as-kw spaces ruleset-id-alias ]
+ruleset-id-d     = ruleset-id-kw DSPs ruleset-id
+import-d         = import-kw DSPs ruleset-id
+                   [ DSPs as-kw DSPs ruleset-id-alias ]
 ruleset-id       = ALPHA *not-space
 not-space        = %x21-10FFFF
 ruleset-id-alias = name
@@ -29,7 +33,7 @@ one-line-directive-parameters = *not-eol
 not-eol          = HTAB / %x20-10FFFF
 eol              = CR / LF
 multi-line-tbd-directive-d = directive-name
-                   [ spaces multi-line-directive-parameters ]
+                   [ 1*sp-cmt multi-line-directive-parameters ]
 multi-line-directive-parameters = multi-line-parameters
 multi-line-parameters = *(comment / q-string / regex /
                    not-multi-line-special)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1150,7 +1150,7 @@ EX5a
 
   it 'should parse jcr-version directive major and minor numbers with 1 extension' do
     ex5a = <<EX5a
-# jcr-version 4.0 (foo_1)
+# jcr-version 4.0 +foo_1-1.0
 # ruleset-id my_awesome_rules
 # import http://arin.net/otherexamples as otherrules
 EX5a
@@ -1161,29 +1161,7 @@ EX5a
 
   it 'should parse jcr-version directive major and minor numbers with 1 extension with leading space' do
     ex5a = <<EX5a
-# jcr-version 4.0 ( foo_1)
-# ruleset-id my_awesome_rules
-# import http://arin.net/otherexamples as otherrules
-EX5a
-    tree = JCR.parse( ex5a )
-    expect(tree[0][:directive][:jcr_version_d][:major_version]).to eq("4")
-    expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
-  end
-
-  it 'should parse jcr-version directive major and minor numbers with 1 extension with trailing space' do
-    ex5a = <<EX5a
-# jcr-version 4.0 (foo_1 )
-# ruleset-id my_awesome_rules
-# import http://arin.net/otherexamples as otherrules
-EX5a
-    tree = JCR.parse( ex5a )
-    expect(tree[0][:directive][:jcr_version_d][:major_version]).to eq("4")
-    expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
-  end
-
-  it 'should parse jcr-version directive major and minor numbers with 1 extension with leading and trailing space' do
-    ex5a = <<EX5a
-# jcr-version 4.0 ( foo_1 )
+# jcr-version 4.0 + foo_1
 # ruleset-id my_awesome_rules
 # import http://arin.net/otherexamples as otherrules
 EX5a
@@ -1194,7 +1172,7 @@ EX5a
 
   it 'should parse jcr-version directive major and minor numbers with 2 extensions' do
     ex5a = <<EX5a
-# jcr-version 4.0 (foo_1 bar_4)
+# jcr-version 4.0 +foo_1 +bar_4
 # ruleset-id my_awesome_rules
 # import http://arin.net/otherexamples as otherrules
 EX5a
@@ -1205,29 +1183,7 @@ EX5a
 
   it 'should parse jcr-version directive major and minor numbers with 2 extensions with leading space' do
     ex5a = <<EX5a
-# jcr-version 4.0 ( foo_1 bar_4)
-# ruleset-id my_awesome_rules
-# import http://arin.net/otherexamples as otherrules
-EX5a
-    tree = JCR.parse( ex5a )
-    expect(tree[0][:directive][:jcr_version_d][:major_version]).to eq("4")
-    expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
-  end
-
-  it 'should parse jcr-version directive major and minor numbers with 2 extensions with trailing space' do
-    ex5a = <<EX5a
-# jcr-version 4.0 (foo_1 bar_4 )
-# ruleset-id my_awesome_rules
-# import http://arin.net/otherexamples as otherrules
-EX5a
-    tree = JCR.parse( ex5a )
-    expect(tree[0][:directive][:jcr_version_d][:major_version]).to eq("4")
-    expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
-  end
-
-  it 'should parse jcr-version directive major and minor numbers with 2 extensions with leading and trailing' do
-    ex5a = <<EX5a
-# jcr-version 4.0 ( foo_1 bar_4 )
+# jcr-version 4.0 + foo_1 + bar_4
 # ruleset-id my_awesome_rules
 # import http://arin.net/otherexamples as otherrules
 EX5a
@@ -1239,7 +1195,19 @@ EX5a
   it 'should parse jcr-version directive major and minor numbers with 2 extensions with leading and trailing two lines' do
     ex5a = %q[
 #{ jcr-version 4.0
-   ( foo_1 bar_4 ) }
+   + foo_1 + bar_4 }
+# ruleset-id my_awesome_rules
+# import http://arin.net/otherexamples as otherrules
+]
+    tree = JCR.parse( ex5a )
+    expect(tree[0][:directive][:jcr_version_d][:major_version]).to eq("4")
+    expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
+  end
+
+  it 'should parse jcr-version directive major and minor numbers with comment & 2 extensions with leading and trailing two lines' do
+    ex5a = %q[
+#{ jcr-version 4.0 ; A comment
+   +foo_1 +bar_4 }
 # ruleset-id my_awesome_rules
 # import http://arin.net/otherexamples as otherrules
 ]
@@ -1252,7 +1220,7 @@ EX5a
     ex5a = %q[
 #{ jcr-version
    4.0
-   ( foo_1 bar_4 ) }
+   + foo_1 + bar_4 }
 # ruleset-id my_awesome_rules
 # import http://arin.net/otherexamples as otherrules
 ]
@@ -1303,6 +1271,18 @@ EX5d
 # import http://arin.net/otherexamples as otherrules
 EX5e
     tree = JCR.parse( ex5e )
+  end
+
+  it 'should permit parsing multi-line unknown directives with early comment' do
+    ex5e = <<'EX5e' # 'EX5e' to prevent #{/...} string interpolation
+#{ constraint; A comment
+  foo
+  $name }
+# ruleset-id my_awesome_rules
+# import http://arin.net/otherexamples as otherrules
+EX5e
+    tree = JCR.parse( ex5e )
+    expect(tree[0][:directive][:directive_name]).to eq("constraint")
   end
 
   it 'should parse multi-line unknown directives with comment, q_strings and regexs' do


### PR DESCRIPTION
I also reverted `extension-id` so we can include the `-1.0` suffix, e.g. `co-constraints-1.0`