### PR TITLE
Plain text serialization fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,5 +206,5 @@ $ bundle install
 To run the unit tests:
 
 ```
-rake test
+$ bundle exec rake test
 ````

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,11 @@ task :test_cli do
   sh "cd examples; bash examples.sh -n"
 end
 
+desc "demonstrate command line examples"
+task :demo_cli do
+  sh "cd examples; bash examples.sh"
+end
+
 desc "run all tests"
 task :test => [:spec, :test_cli, :test_ruby_examples ]
 

--- a/lib/jcr/evaluate_array_rules.rb
+++ b/lib/jcr/evaluate_array_rules.rb
@@ -289,6 +289,6 @@ module JCR
 
   def self.array_to_s( jcr, shallow=true )
     rules, annotations = get_rules_and_annotations( jcr )
-    return "#{annotations_to_s( annotations)} [ #{rules_to_s( rules, shallow )} ]"
+    return "#{annotations_to_s( annotations)}[ #{rules_to_s( rules, shallow )} ]"
   end
 end

--- a/lib/jcr/evaluate_group_rules.rb
+++ b/lib/jcr/evaluate_group_rules.rb
@@ -58,7 +58,7 @@ module JCR
 
   def self.group_to_s( jcr, shallow=true)
     rules, annotations = get_rules_and_annotations( jcr )
-    return "#{annotations_to_s( annotations)} ( #{rules_to_s(rules,shallow)} )"
+    return "#{annotations_to_s( annotations)}( #{rules_to_s(rules,shallow)} )"
   end
 
 end

--- a/lib/jcr/evaluate_object_rules.rb
+++ b/lib/jcr/evaluate_object_rules.rb
@@ -174,6 +174,6 @@ module JCR
 
   def self.object_to_s( jcr, shallow=true )
     rules, annotations = get_rules_and_annotations( jcr )
-    return "#{annotations_to_s( annotations)} { #{rules_to_s(rules,shallow)} }"
+    return "#{annotations_to_s( annotations)}{ #{rules_to_s(rules,shallow)} }"
   end
 end

--- a/lib/jcr/evaluate_rules.rb
+++ b/lib/jcr/evaluate_rules.rb
@@ -373,6 +373,16 @@ module JCR
   end
 
   def self.rule_to_s( rule, shallow=true)
+    if rule[:rule_name]
+      retval = "$#{rule[:rule_name].to_s} = #{ruletype_to_s( rule, shallow )}"
+    else
+      retval = ruletype_to_s( rule, shallow )
+    end
+    return retval
+  end
+
+  def self.ruletype_to_s( rule, shallow=true )
+
     if rule[:primitive_rule]
       retval = value_to_s( rule[:primitive_rule] )
     elsif rule[:member_rule]
@@ -393,6 +403,7 @@ module JCR
       retval = "** unknown rule definition ** #{rule}"
     end
     return retval
+
   end
 
   def self.rules_to_s( rules, shallow=true)
@@ -415,13 +426,13 @@ module JCR
     annotations.each do |a|
       case
         when a[:unordered_annotation]
-          retval = retval + " @{unordered}"
+          retval = retval + "@{unordered}"
         when a[:not_annotation]
-          retval = retval + " @{not}"
+          retval = retval + "@{not}"
         when a[:root_annotation]
-          retval = retval + " @{root}"
+          retval = retval + "@{root}"
         else
-          retval = retval + " @{ ** unknown annotation ** }"
+          retval = retval + "@{ ** unknown annotation ** }"
       end
     end if annotations
     retval = retval + " " if retval.length != 0
@@ -429,7 +440,7 @@ module JCR
   end
 
   def self.target_to_s( jcr )
-    return annotations_to_s( jcr[:annotations] ) + " target: " + jcr[:rule_name].to_s
+    return annotations_to_s( jcr[:annotations] ) + "$" + jcr[:rule_name].to_s
   end
 
 end

--- a/lib/jcr/evaluate_value_rules.rb
+++ b/lib/jcr/evaluate_value_rules.rb
@@ -470,9 +470,9 @@ module JCR
 
       when rule[:uri]
         if rule[:uri].is_a? Hash
-          retval =  "URI with specific scheme #{rule[:uri][:uri_scheme].to_s}"
+          retval =  "uri..#{rule[:uri][:uri_scheme].to_s}"
         else
-          retval =  "URI"
+          retval =  "uri"
         end
 
       when rule[:email]

--- a/spec/evaluate_rules_spec.rb
+++ b/spec/evaluate_rules_spec.rb
@@ -100,6 +100,11 @@ describe 'evaluate_rules' do
     expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ "foo" , 2 , 2.3 , true , false , null ]')
   end
 
+  it 'should print out an array with a regex' do
+    tree = JCR.parse( '[ /foo*/ ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ /foo*/ ]')
+  end
+
   it 'should print out an array with ranges' do
     tree = JCR.parse( '[ 0..1, 0.., ..2, 1.1..2.2, 2.2.., ..3.3 ]' )
     expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ 0..1 , 0..INF , -INF..2 , 1.1..2.2 , 2.2..INF , -INF..3.3 ]')
@@ -108,6 +113,21 @@ describe 'evaluate_rules' do
   it 'should print out an array with primitive definitions' do
     tree = JCR.parse( '[ integer, string, float, double, any, boolean ]' )
     expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ integer , string , float , double , any , boolean ]')
+  end
+
+  it 'should print out sized int primitive definitions' do
+    tree = JCR.parse( '[ int8, uint16 ]')
+    expect( JCR.rule_to_s( tree[0] ) ).to eq('[ int8 , uint16 ]')
+  end
+
+  it 'should print out an array with other primitive definitions' do
+    tree = JCR.parse( '[ ipv4, ipv6, fqdn, idn, email, phone, hex, base32hex, base64url, base64, datetime, date, time ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ ipv4 , ipv6 , fqdn , idn , email , phone , hex , base32hex , base64url , base64 , datetime , date , time ]')
+  end
+
+  it 'should print uris' do
+    tree = JCR.parse( '[ uri, uri..https, uri..ftp ]')
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ uri , uri..https , uri..ftp ]' )
   end
 
   it 'should print out an array of arrays with annotations' do

--- a/spec/evaluate_rules_spec.rb
+++ b/spec/evaluate_rules_spec.rb
@@ -76,4 +76,58 @@ describe 'evaluate_rules' do
     expect( max ).to eq(1)
   end
 
+  #
+  # plain text serialization
+  #
+
+  it 'should print out an array with a rule reference' do
+    tree = JCR.parse( '[ $t ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( "[ $t ]")
+  end
+
+  it 'should print out an array with two strings anded in it' do
+    tree = JCR.parse( '[ "foo", "bar" ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ "foo" , "bar" ]')
+  end
+
+  it 'should print out an array with two strings ored in it' do
+    tree = JCR.parse( '[ "foo"| "bar" ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ "foo" | "bar" ]')
+  end
+
+  it 'should print out an array with primitives' do
+    tree = JCR.parse( '[ "foo", 2, 2.3, true, false, null ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ "foo" , 2 , 2.3 , true , false , null ]')
+  end
+
+  it 'should print out an array with ranges' do
+    tree = JCR.parse( '[ 0..1, 0.., ..2, 1.1..2.2, 2.2.., ..3.3 ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ 0..1 , 0..INF , -INF..2 , 1.1..2.2 , 2.2..INF , -INF..3.3 ]')
+  end
+
+  it 'should print out an array with primitive definitions' do
+    tree = JCR.parse( '[ integer, string, float, double, any, boolean ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ integer , string , float , double , any , boolean ]')
+  end
+
+  it 'should print out an array of arrays with annotations' do
+    tree = JCR.parse( '[ @{not}[ integer ], @{root}[ string ] , @{unordered}[ float ] ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ @{not} [ integer ] , @{root} [ string ] , @{unordered} [ float ] ]')
+  end
+
+  it 'should print an object with members' do
+    tree = JCR.parse( '{ "a":string, "b":integer }' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '{ "a" : string , "b" : integer }')
+  end
+
+  it 'should print an group with members' do
+    tree = JCR.parse( '( "a":string, "b":integer )' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '( "a" : string , "b" : integer )')
+  end
+
+  it 'should print out a rule assignment' do
+    tree = JCR.parse( '$t = [ string ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '$t = [ string ]' )
+  end
+
 end

--- a/spec/evaluate_rules_spec.rb
+++ b/spec/evaluate_rules_spec.rb
@@ -125,9 +125,29 @@ describe 'evaluate_rules' do
     expect( JCR.rule_to_s( tree[0] ) ).to eq( '( "a" : string , "b" : integer )')
   end
 
-  it 'should print out a rule assignment' do
+  it 'should print out a rule assignment to an array' do
     tree = JCR.parse( '$t = [ string ]' )
     expect( JCR.rule_to_s( tree[0] ) ).to eq( '$t = [ string ]' )
+  end
+
+  it 'should print out a rule assignment to member rule' do
+    tree = JCR.parse( '$t = "a":string' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '$t = "a" : string' )
+  end
+
+  it 'should print out a rule assignment to a primitive rule' do
+    tree = JCR.parse( '$t =: "foo"' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '$t =: "foo"' )
+  end
+
+  it 'should print repetitions in an array' do
+    tree = JCR.parse( '[ integer?, string*, float *1, boolean *1..2, null *..2, double *1.., string ? ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ integer ? , string * , float *1 , boolean *1..2 , null *0..2 , double *1..INF , string ? ]' )
+  end
+
+  it 'should print repetitions with steps in an array' do
+    tree = JCR.parse( '[ string*%3, boolean *1..2%3, null *..2%3, double *1..%3 ]' )
+    expect( JCR.rule_to_s( tree[0] ) ).to eq( '[ string *%3 , boolean *1..2%3 , null *0..2%3 , double *1..INF%3 ]' )
   end
 
 end


### PR DESCRIPTION
this changes the plain text serialization to be more in line with the actual JCR syntax.
It also adds repetitions to the serialization which were missing before, fixes some spacing issues,
and adds tests.