### PR TITLE
Changed ABNF and parslet code to include annotations for groups in

### DIFF
--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -317,8 +317,8 @@ module JCR
         #! object_item = object_item_types spcCmnt? [ repetition ]
     rule(:object_item_types) { object_group | member_rule | target_rule_name }
         #! object_item_types = object_group / member_rule / target_rule_name
-    rule(:object_group) { ( str('(') >> spcCmnt? >> object_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
-        #! object_group = "(" spcCmnt? [ object_items spcCmnt? ] ")"
+    rule(:object_group) { ( annotations >> str('(') >> spcCmnt? >> object_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
+        #! object_group = annotations "(" spcCmnt? [ object_items spcCmnt? ] ")"
         #!
 
       rule(:array_rule)   { ( annotations >>
@@ -332,8 +332,8 @@ module JCR
         #! array_item = array_item_types spcCmnt? [ repetition ]
     rule(:array_item_types) { array_group | type_rule | explicit_type_choice }
         #! array_item_types = array_group / type_rule / explicit_type_choice
-    rule(:array_group)  { ( str('(') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
-        #! array_group = "(" spcCmnt? [ array_items spcCmnt? ] ")"
+    rule(:array_group)  { ( annotations >> str('(') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
+        #! array_group = annotations "(" spcCmnt? [ array_items spcCmnt? ] ")"
         #!
 
     rule(:group_rule)   { ( annotations >> str('(') >> spcCmnt? >> group_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1663,4 +1663,73 @@ EX12
     JCR.parse( '{ "n" : 1 *1 }' )
   end
 
+  it 'should parse an object rule with an annotated group' do
+    tree = JCR.parse( '{ "a" : string , @{not}( "b" : integer, "c" : boolean ) }')
+    # produces the following tree
+    # [{:object_rule=>
+    #       [{:member_rule=>
+    #             {:member_name=>{:q_string=>"a"@3},
+    #              :primitive_rule=>{:string=>"string"@8}}},
+    #        {:sequence_combiner=>","@15,
+    #         :group_rule=>
+    #             [{:not_annotation=>"not"@19},
+    #              {:member_rule=>
+    #                   {:member_name=>{:q_string=>"b"@26},
+    #                    :primitive_rule=>{:integer_v=>"integer"@31}}},
+    #              {:sequence_combiner=>","@38,
+    #               :member_rule=>
+    #                   {:member_name=>{:q_string=>"c"@41},
+    #                    :primitive_rule=>{:boolean_v=>"boolean"@46}}}]}]}]
+    expect(tree[0][:object_rule][1][:group_rule][0][:not_annotation]).to_not be_nil
+  end
+
+  it 'should parse an object rule with an annotated group and a repetition' do
+    tree = JCR.parse( '{ "a" : string , @{not}( "b" : integer, "c" : boolean ) ? }')
+    # produces the following tree
+    # [{:object_rule=>
+    #       [{:member_rule=>
+    #             {:member_name=>{:q_string=>"a"@3},
+    #              :primitive_rule=>{:string=>"string"@8}}},
+    #        {:sequence_combiner=>","@15,
+    #         :group_rule=>
+    #             [{:not_annotation=>"not"@19},
+    #              {:member_rule=>
+    #                   {:member_name=>{:q_string=>"b"@26},
+    #                    :primitive_rule=>{:integer_v=>"integer"@31}}},
+    #              {:sequence_combiner=>","@38,
+    #               :member_rule=>
+    #                   {:member_name=>{:q_string=>"c"@41},
+    #                    :primitive_rule=>{:boolean_v=>"boolean"@46}}}],
+    #         :optional=>"?"@56}]}]
+    expect(tree[0][:object_rule][1][:group_rule][0][:not_annotation]).to_not be_nil
+    expect(tree[0][:object_rule][1][:optional]).to_not be_nil
+  end
+
+  it 'should parse an array rule with an annotated group' do
+    tree = JCR.parse( '[ string , @{not} ( integer * ) ]')
+    # produces the following tree
+    # [{:array_rule=>
+    #       [{:primitive_rule=>{:string=>"string"@2}},
+    #        {:sequence_combiner=>","@9,
+    #         :group_rule=>
+    #             [{:not_annotation=>"not"@13},
+    #              {:primitive_rule=>{:integer_v=>"integer"@20},
+    #               :zero_or_more=>"*"@28}]}]}]
+    expect(tree[0][:array_rule][1][:group_rule][0][:not_annotation]).to_not be_nil
+  end
+
+  it 'should parse an array rule with an annotated group and a repetition' do
+    tree = JCR.parse( '[ string , @{not} ( integer * ) ? ]')
+    # produces the following tree
+    # [{:array_rule=>
+    #       [{:primitive_rule=>{:string=>"string"@2}},
+    #        {:sequence_combiner=>","@9,
+    #         :group_rule=>
+    #             [{:not_annotation=>"not"@13},
+    #              {:primitive_rule=>{:integer_v=>"integer"@20}, :zero_or_more=>"*"@28}],
+    #         :optional=>"?"@32}]}]
+    expect(tree[0][:array_rule][1][:group_rule][0][:not_annotation]).to_not be_nil
+    expect(tree[0][:array_rule][1][:optional]).to_not be_nil
+  end
+
 end


### PR DESCRIPTION
arrays and objects.
I added some parser tests for this, and some additional parser tests
for repetitions on groups in arrays and objects because I didn't see
any tests for that.