### PR TITLE
Refactored combiners

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -135,29 +135,29 @@ any              = any-kw
 
 object-rule      = annotations "{" *sp-cmt
                    [ object-items *sp-cmt ] "}"
-object-items     = object-item (*( sequence-combiner object-item ) /
-                   *( choice-combiner object-item ) )
-object-item      = object-item-types *sp-cmt [ repetition ]
+object-items     = object-item [ 1*( sequence-combiner object-item ) /
+                   1*( choice-combiner object-item ) ]
+object-item      = object-item-types *sp-cmt [ repetition *sp-cmt ]
 object-item-types = object-group / member-rule / target-rule-name
-object-group     = "(" *sp-cmt [ object-items *sp-cmt ] ")"
+object-group     = annotations "(" *sp-cmt [ object-items *sp-cmt ] ")"
 
 array-rule       = annotations "[" *sp-cmt [ array-items *sp-cmt ] "]"
-array-items      = array-item (*( sequence-combiner array-item ) /
-                   *( choice-combiner array-item ) )
-array-item       = array-item-types *sp-cmt [ repetition ]
+array-items      = array-item [ 1*( sequence-combiner array-item ) /
+                   1*( choice-combiner array-item ) ]
+array-item       = array-item-types *sp-cmt [ repetition *sp-cmt ]
 array-item-types = array-group / type-rule / explicit-type-choice
-array-group      = "(" *sp-cmt [ array-items *sp-cmt ] ")"
+array-group      = annotations "(" *sp-cmt [ array-items *sp-cmt ] ")"
 
 group-rule       = annotations "(" *sp-cmt [ group-items *sp-cmt ] ")"
-group-items      = group-item (*( sequence-combiner group-item ) /
-                   *( choice-combiner group-item ) )
-group-item       = group-item-types *sp-cmt [ repetition ]
+group-items      = group-item [ 1*( sequence-combiner group-item ) /
+                   1*( choice-combiner group-item ) ]
+group-item       = group-item-types *sp-cmt [ repetition *sp-cmt ]
 group-item-types = group-group / member-rule /
                    type-rule / explicit-type-choice
 group-group      = group-rule
 
-sequence-combiner = *sp-cmt "," *sp-cmt
-choice-combiner  = *sp-cmt "|" *sp-cmt
+sequence-combiner = "," *sp-cmt
+choice-combiner  = "|" *sp-cmt
 
 repetition       = optional / one-or-more /
                    repetition-range / zero-or-more

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -309,12 +309,12 @@ module JCR
               str('{') >> spcCmnt? >> object_items.maybe >> spcCmnt? >> str('}') ).as(:object_rule) }
         #! object_rule = annotations "{" spcCmnt?
         #!                               [ object_items spcCmnt? ] "}"
-    rule(:object_items) { object_item >> (( spcCmnt? >> sequence_combiner >> spcCmnt? >> object_item ).repeat(1) |
-                                          ( spcCmnt? >> choice_combiner >> spcCmnt? >> object_item ).repeat(1) ).maybe }
+    rule(:object_items) { object_item >> (( sequence_combiner >> object_item ).repeat(1) |
+                                          ( choice_combiner >> object_item ).repeat(1) ).maybe }
         #! object_items = object_item (*( sequence_combiner object_item ) /
         #!                             *( choice_combiner object_item ) )
-    rule(:object_item ) { object_item_types >> spcCmnt? >> repetition.maybe }
-        #! object_item = object_item_types spcCmnt? [ repetition ]
+    rule(:object_item ) { object_item_types >> spcCmnt? >> repetition.maybe >> spcCmnt? }
+        #! object_item = object_item_types spcCmnt? [ repetition spcCmnt? ]
     rule(:object_item_types) { object_group | member_rule | target_rule_name }
         #! object_item_types = object_group / member_rule / target_rule_name
     rule(:object_group) { ( annotations >> str('(') >> spcCmnt? >> object_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
@@ -324,12 +324,12 @@ module JCR
       rule(:array_rule)   { ( annotations >>
               str('[') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(']') ).as(:array_rule) }
         #! array_rule = annotations "[" spcCmnt? [ array_items spcCmnt? ] "]"
-    rule(:array_items)  { array_item >> (( spcCmnt? >> sequence_combiner >> spcCmnt? >> array_item ).repeat(1) |
-                                         ( spcCmnt? >> choice_combiner >> spcCmnt? >> array_item ).repeat(1) ).maybe }
+    rule(:array_items)  { array_item >> (( sequence_combiner >> array_item ).repeat(1) |
+                                         ( choice_combiner >> array_item ).repeat(1) ).maybe }
         #! array_items = array_item (*( sequence_combiner array_item ) /
         #!                           *( choice_combiner array_item ) )
-    rule(:array_item)   { array_item_types >> spcCmnt? >> repetition.maybe }
-        #! array_item = array_item_types spcCmnt? [ repetition ]
+    rule(:array_item)   { array_item_types >> spcCmnt? >> repetition.maybe >> spcCmnt? }
+        #! array_item = array_item_types spcCmnt? [ repetition spcCmnt? ]
     rule(:array_item_types) { array_group | type_rule | explicit_type_choice }
         #! array_item_types = array_group / type_rule / explicit_type_choice
     rule(:array_group)  { ( annotations >> str('(') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
@@ -338,12 +338,12 @@ module JCR
 
     rule(:group_rule)   { ( annotations >> str('(') >> spcCmnt? >> group_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
         #! group_rule = annotations "(" spcCmnt? [ group_items spcCmnt? ] ")"
-    rule(:group_items)  { group_item >> (( spcCmnt? >> sequence_combiner >> spcCmnt? >> group_item ).repeat(1) |
-                                         ( spcCmnt? >> choice_combiner >> spcCmnt? >> group_item ).repeat(1) ).maybe }
+    rule(:group_items)  { group_item >> (( sequence_combiner >> group_item ).repeat(1) |
+                                         ( choice_combiner >> group_item ).repeat(1) ).maybe }
         #! group_items = group_item (*( sequence_combiner group_item ) /
         #!                           *( choice_combiner group_item ) )
-    rule(:group_item)   { group_item_types >> spcCmnt? >> repetition.maybe }
-        #! group_item = group_item_types spcCmnt? [ repetition ]
+    rule(:group_item)   { group_item_types >> spcCmnt? >> repetition.maybe >> spcCmnt? }
+        #! group_item = group_item_types spcCmnt? [ repetition spcCmnt? ]
     rule(:group_item_types) { group_group | member_rule | type_rule | explicit_type_choice }
         #! group_item_types = group_group / member_rule /
         #!                    type_rule / explicit_type_choice
@@ -351,10 +351,10 @@ module JCR
         #! group_group = group_rule
         #!
 
-    rule(:sequence_combiner)  { str(',').as(:sequence_combiner) }
-        #! sequence_combiner = spcCmnt? "," spcCmnt?
-    rule(:choice_combiner)    { str('|').as(:choice_combiner) }
-        #! choice_combiner = spcCmnt? "|" spcCmnt?
+    rule(:sequence_combiner)  { str(',').as(:sequence_combiner) >> spcCmnt? }
+        #! sequence_combiner = "," spcCmnt?
+    rule(:choice_combiner)    { str('|').as(:choice_combiner) >> spcCmnt? }
+        #! choice_combiner = "|" spcCmnt?
         #!
 
     rule(:repetition)          { optional | one_or_more |

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -311,9 +311,9 @@ module JCR
         #!                               [ object_items spcCmnt? ] "}"
     rule(:object_items) { object_item >> (( sequence_combiner >> object_item ).repeat(1) |
                                           ( choice_combiner >> object_item ).repeat(1) ).maybe }
-        #! object_items = object_item (*( sequence_combiner object_item ) /
-        #!                             *( choice_combiner object_item ) )
-    rule(:object_item ) { object_item_types >> spcCmnt? >> repetition.maybe >> spcCmnt? }
+        #! object_items = object_item [ 1*( sequence_combiner object_item ) /
+        #!                             1*( choice_combiner object_item ) ]
+    rule(:object_item ) { object_item_types >> spcCmnt? >> ( repetition >> spcCmnt? ).maybe }
         #! object_item = object_item_types spcCmnt? [ repetition spcCmnt? ]
     rule(:object_item_types) { object_group | member_rule | target_rule_name }
         #! object_item_types = object_group / member_rule / target_rule_name
@@ -326,9 +326,9 @@ module JCR
         #! array_rule = annotations "[" spcCmnt? [ array_items spcCmnt? ] "]"
     rule(:array_items)  { array_item >> (( sequence_combiner >> array_item ).repeat(1) |
                                          ( choice_combiner >> array_item ).repeat(1) ).maybe }
-        #! array_items = array_item (*( sequence_combiner array_item ) /
-        #!                           *( choice_combiner array_item ) )
-    rule(:array_item)   { array_item_types >> spcCmnt? >> repetition.maybe >> spcCmnt? }
+        #! array_items = array_item [ 1*( sequence_combiner array_item ) /
+        #!                           1*( choice_combiner array_item ) ]
+    rule(:array_item)   { array_item_types >> spcCmnt? >> ( repetition >> spcCmnt? ).maybe }
         #! array_item = array_item_types spcCmnt? [ repetition spcCmnt? ]
     rule(:array_item_types) { array_group | type_rule | explicit_type_choice }
         #! array_item_types = array_group / type_rule / explicit_type_choice
@@ -340,9 +340,9 @@ module JCR
         #! group_rule = annotations "(" spcCmnt? [ group_items spcCmnt? ] ")"
     rule(:group_items)  { group_item >> (( sequence_combiner >> group_item ).repeat(1) |
                                          ( choice_combiner >> group_item ).repeat(1) ).maybe }
-        #! group_items = group_item (*( sequence_combiner group_item ) /
-        #!                           *( choice_combiner group_item ) )
-    rule(:group_item)   { group_item_types >> spcCmnt? >> repetition.maybe >> spcCmnt? }
+        #! group_items = group_item [ 1*( sequence_combiner group_item ) /
+        #!                           1*( choice_combiner group_item ) ]
+    rule(:group_item)   { group_item_types >> spcCmnt? >> ( repetition >> spcCmnt? ).maybe }
         #! group_item = group_item_types spcCmnt? [ repetition spcCmnt? ]
     rule(:group_item_types) { group_group | member_rule | type_rule | explicit_type_choice }
         #! group_item_types = group_group / member_rule /


### PR DESCRIPTION
This is the ABNF changes to object_items, array_items, group_items to align to Parslet code.

I've also moved position of spcCmnt? in above rules, and sequence_combiner and
choice_combiner to make the ABNF cleaner and align the Parslet with the ABNF.

Please ignore the "Failed attempt to avoid (repeat(1)/repeat(1)).maybe construct" commit message! I forgot to reset before making the second change!

Also, this version includes the addition of annotations to object-group etc. in abnf/jcr-abnf.txt.  I guess we didn't re-extract the ABNF after that change.