### PR TITLE
Disallow closing brace in extension-id and ruleset-id

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -24,12 +24,13 @@ jcr-version-d    = jcr-version-kw DSPs major-version
                    *( DSPs "+" [ DSPs ] extension-id )
 major-version    = non-neg-integer
 minor-version    = non-neg-integer
-extension-id     = ALPHA *not-space
+extension-id     = id
+id               = ALPHA *id-tail
+id-tail          = %x21-7C / %x7E-10FFFF ; not spaces, not }
 ruleset-id-d     = ruleset-id-kw DSPs ruleset-id
 import-d         = import-kw DSPs ruleset-id
                    [ DSPs as-kw DSPs ruleset-id-alias ]
-ruleset-id       = ALPHA *not-space
-not-space        = %x21-10FFFF
+ruleset-id       = id
 ruleset-id-alias = name
 one-line-tbd-directive-d = directive-name
                    [ WSP one-line-directive-parameters ]

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -72,8 +72,12 @@ module JCR
         #> jcr-version-kw = "jcr-version"
         #! major_version = non_neg_integer
         #! minor_version = non_neg_integer
-    rule(:extension_id)  { match('[a-zA-Z]') >> match('[\S]').repeat }
-        #! extension_id = ALPHA *not-space
+    rule(:extension_id)  { id }
+        #! extension_id = id
+    rule(:id)  { match('[a-zA-Z]') >> id_tail.repeat }
+        #! id = ALPHA *id-tail
+    rule(:id_tail)  { match('[^\s}]') }
+        #! id-tail = %x21-7C / %x7E-10FFFF ; not spaces, not }
     rule(:ruleset_id_d)  { (str('ruleset-id') >> dsps >> ruleset_id.as(:ruleset_id)).as(:ruleset_id_d) }
         #! ruleset_id_d = ruleset-id-kw DSPs ruleset_id
         #> ruleset-id-kw = "ruleset-id"
@@ -82,9 +86,8 @@ module JCR
         #!            [ DSPs as_kw DSPs ruleset_id_alias ]
         #> import-kw = "import"
         #> as-kw = "as"
-    rule(:ruleset_id)        { match('[a-zA-Z]') >> match('[\S]').repeat }
-        #! ruleset_id = ALPHA *not-space
-        #! not-space = %x21-10FFFF
+    rule(:ruleset_id)        { id }
+        #! ruleset_id = id
     rule(:ruleset_id_alias)  { name.as(:ruleset_id_alias) }
         #! ruleset_id_alias = name
     rule(:one_line_tbd_directive_d) { name.as(:directive_name) >> ( wsp >> match('[^\r\n]').repeat.as(:directive_parameters) ).maybe }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1230,6 +1230,17 @@ EX5a
     expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
   end
 
+  it 'should parse multi-line jcr-version directive major and minor numbers with 2 extensions with immediate closing brace' do
+    ex = %q[
+#{ jcr-version
+   4.0
+   + foo_1 + bar_4}
+]
+    tree = JCR.parse( ex )
+    expect(tree[0][:directive][:jcr_version_d][:major_version]).to eq("4")
+    expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
+  end
+
   it 'should parse directives with spaces after them' do
   # Note: ~ characters in JCR below changed to spaces by the gsub() regular expression
     ex5b = <<EX5b
@@ -1254,10 +1265,48 @@ EX5c
     expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
   end
 
+  it 'should parse multi-line jcr-version directive major and minor numbers with immediate closing brace' do
+    ex5c = <<'EX5c' # 'EX5c' to prevent #{/...} string interpolation
+#{jcr-version
+  4.0}
+# ruleset-id my_awesome_rules
+# import http://arin.net/otherexamples as otherrules
+EX5c
+    tree = JCR.parse( ex5c )
+    expect(tree[0][:directive][:jcr_version_d][:major_version]).to eq("4")
+    expect(tree[0][:directive][:jcr_version_d][:minor_version]).to eq("0")
+  end
+
+  it 'should parse multi-line ruleset-id with immediate closing brace' do
+    ex = %q[
+#{ruleset-id my_awesome_rules}
+]
+    tree = JCR.parse( ex )
+    expect(tree[0][:directive][:ruleset_id_d][:ruleset_id]).to eq("my_awesome_rules")
+  end
+
+  it 'should parse multi-line import with immediate closing brace' do
+    ex = %q[
+#{import my_awesome_rules}
+]
+    tree = JCR.parse( ex )
+    expect(tree[0][:directive][:import_d][:ruleset_id]).to eq("my_awesome_rules")
+  end
+
   it 'should permit parsing multi-line unknown directives' do
     ex5d = <<'EX5d' # 'EX5d' to prevent #{/...} string interpolation
 #{constraint foo
   $name }
+# ruleset-id my_awesome_rules
+# import http://arin.net/otherexamples as otherrules
+EX5d
+    tree = JCR.parse( ex5d )
+  end
+
+  it 'should permit parsing multi-line unknown directives with immediate closing brace' do
+    ex5d = <<'EX5d' # 'EX5d' to prevent #{/...} string interpolation
+#{constraint foo
+  $name}
 # ruleset-id my_awesome_rules
 # import http://arin.net/otherexamples as otherrules
 EX5d


### PR DESCRIPTION
PR to disallow } in extension-id and ruleset-id to address issue #101.

By way of implementation, I added an `id` ABNF rule to factor out the common ABNF.