### PR TITLE
Fixed overzealous conversion of _ underscores to - hyphens in ABNF extractor

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -55,7 +55,7 @@ rule-name        = name
 target-rule-name = annotations "$"
                    [ ruleset-id-alias "." ]
                    rule-name
-name             = ALPHA *( ALPHA / DIGIT / "-" / "-" )
+name             = ALPHA *( ALPHA / DIGIT / "-" / "_" )
 
 rule-def         = member-rule / type-designator rule-def-type-rule /
                    array-rule / object-rule / group-rule /

--- a/abnf/make-abnf.rb
+++ b/abnf/make-abnf.rb
@@ -82,7 +82,7 @@ def do_name_mappings( line )
     for mapping_from in mapping_keys_sorted_longest_first
         line.gsub!( mapping_from, $mappings[mapping_from] )
     end
-    line.gsub!( '_', '-' )
+    line.gsub!( /(\w)_(\w)/, '\1-\2' )
     return line
 end
 


### PR DESCRIPTION
Noticed that my ABNF extractor, incorrectly converted `"_"` to `"-"` giving the rule:

    name             = ALPHA *( ALPHA / DIGIT / "-" / "-" )

instead of:

    name             = ALPHA *( ALPHA / DIGIT / "-" / "_" )

This PR fixes it. (Important for the RFC.)