### PR TITLE
Remove equal colon

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -58,8 +58,7 @@ target-rule-name = annotations "$"
 name             = ALPHA *( ALPHA / DIGIT / "-" / "_" )
 
 rule-def         = member-rule / type-designator rule-def-type-rule /
-                   array-rule / object-rule / group-rule /
-                   target-rule-name
+                   value-rule / group-rule / target-rule-name
 type-designator  = type-kw 1*sp-cmt / ":" *sp-cmt
 rule-def-type-rule = value-rule / type-choice
 value-rule       = primitive-rule / array-rule / object-rule

--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -65,7 +65,7 @@ rule-def-type-rule = value-rule / type-choice
 value-rule       = primitive-rule / array-rule / object-rule
 member-rule      = annotations
                    member-name-spec *sp-cmt ":" *sp-cmt type-rule
-member-name-spec = regex / q-string
+member-name-spec = backtick-regex / q-string
 type-rule        = value-rule / type-choice / target-rule-name
 type-choice      = annotations "(" type-choice-items
                    *( choice-combiner type-choice-items ) ")"
@@ -227,6 +227,9 @@ not-slash        = HTAB / CR / LF / %x20-2E / %x30-10FFFF
                    ; Any char except "/"
 regex-modifiers  = *( "i" / "s" / "x" )
 
+backtick-regex   = "`" *( escape "`" / not-backtick ) "`"
+not-backtick     = HTAB / CR / LF / %x20-5F / %x61-10FFFF
+                   ; Any char except "`"
 uri-scheme       = 1*ALPHA
 
 ;; Keywords

--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -84,7 +84,7 @@ annotation-name  = name
 annotation-parameters = multi-line-parameters
 
 primitive-rule   = annotations primitive-def
-primitive-def    = string-type / string-range / string-value /
+primitive-def    = string-type / string-range / string-value1 / string-value2 /
                    null-type / boolean-type / true-value /
                    false-value / double-type / float-type /
                    float-range / float-value /
@@ -100,7 +100,8 @@ boolean-type     = boolean-kw
 true-value       = true-kw
 false-value      = false-kw
 string-type      = string-kw
-string-value     = q-string
+string-value1    = sq-string
+string-value2    = q-string
 string-range     = regex
 double-type      = double-kw
 float-type       = float-kw
@@ -194,22 +195,31 @@ exp              = e [ minus / plus ] 1*DIGIT
 e                = %x65 / %x45                   ; e E
 zero             = %x30                          ; 0
 
-q-string         = quotation-mark *char quotation-mark 
-                   ; From RFC 7159
+q-string         = quotation-mark *char quotation-mark
+                   ; Derive from RFC 7159
+quotation-mark   = %x22      ; "    quotation mark  U+0022
 char             = unescaped /
                    escape (
-                   %x22 /          ; "    quotation mark  U+0022
-                   %x5C /          ; \    reverse solidus U+005C
+                   quotation-mark /
+                   escape-codes )
+unescaped        = %x20-21 / %x23-5B / %x5D-10FFFF
+escape           = %x5C              ; \
+escape-codes     = 
                    %x2F /          ; /    solidus         U+002F
                    %x62 /          ; b    backspace       U+0008
                    %x66 /          ; f    form feed       U+000C
                    %x6E /          ; n    line feed       U+000A
                    %x72 /          ; r    carriage return U+000D
                    %x74 /          ; t    tab             U+0009
-                   %x75 4HEXDIG )  ; uXXXX                U+XXXX
-escape           = %x5C              ; \
-quotation-mark   = %x22      ; "
-unescaped        = %x20-21 / %x23-5B / %x5D-10FFFF
+                   %x75 4HEXDIG    ; uXXXX                U+XXXX
+
+sq-string        = single-quote-mark *sq-char single-quote-mark
+single-quote-mark = %x27      ; '    single quotation mark  U+0027
+sq-char          = sq-unescaped /
+                   escape (
+                   single-quote-mark /
+                   escape-codes )
+sq-unescaped     = %x20-26 / %x28-5B / %x5D-10FFFF ; Not ' or \
 
 regex            = "/" *( escape "/" / not-slash ) "/"
                    [ regex-modifiers ]

--- a/lib/jcr/evaluate_member_rules.rb
+++ b/lib/jcr/evaluate_member_rules.rb
@@ -60,7 +60,7 @@ module JCR
         match_spec = Regexp.new( "" )
         trace( econs, "Noting empty regular expression." )
       else
-        match_spec = Regexp.new( rule[:member_regex][:regex].to_s )
+        match_spec = Regexp.new( "^#{rule[:member_regex][:regex].to_s}$" )
       end
       if match_spec =~ data[ 0 ]
         member_match = true

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -143,8 +143,8 @@ module JCR
     rule(:member_rule)       { ( annotations >> member_name_spec >> spcCmnt? >> str(':') >> spcCmnt? >> type_rule ).as(:member_rule) }
         #! member_rule = annotations
         #!               member_name_spec spcCmnt? ":" spcCmnt? type_rule
-    rule(:member_name_spec)  { regex.as(:member_regex) | q_string.as(:member_name) }
-        #! member_name_spec = regex / q_string
+    rule(:member_name_spec)  { backtick_regex.as(:member_regex) | q_string.as(:member_name) }
+        #! member_name_spec = backtick_regex / q_string
     rule(:type_rule)         { value_rule | type_choice | target_rule_name }
         #! type_rule = value_rule / type_choice / target_rule_name
     rule(:type_choice)       { ( annotations >> str('(') >> type_choice_items >> ( choice_combiner >> type_choice_items ).repeat >> str(')') ).as(:group_rule) }
@@ -466,6 +466,11 @@ module JCR
     rule(:regex_modifiers) { match('[isx]').repeat.as(:regex_modifiers) }
         #! regex_modifiers = *( "i" / "s" / "x" )
         #!
+
+    rule(:backtick_regex)     { str('`') >> (str('\\`') | match('[^`]+')).repeat.as(:regex) >> str('`') }
+        #! backtick_regex = "`" *( escape "`" / not-backtick ) "`"
+        #! not-backtick = HTAB / CR / LF / %x20-5F / %x61-10FFFF
+        #!             ; Any char except "`"
 
     rule(:uri_scheme) { ( match('[a-zA-Z]').repeat(1) ).as(:uri_scheme) }
         #! uri_scheme = 1*ALPHA

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -129,10 +129,9 @@ module JCR
         #!
 
     rule(:rule_def)          { member_rule | (type_designator >> rule_def_type_rule) | 
-                               array_rule | object_rule | group_rule | target_rule_name }
+                               value_rule | group_rule | target_rule_name }
         #! rule_def = member_rule / type_designator rule_def_type_rule /
-        #!            array_rule / object_rule / group_rule /
-        #!            target_rule_name
+        #!            value_rule / group_rule / target_rule_name
     rule(:type_designator)   { str('type') >> spcCmnt.repeat(1) | str(':') >> spcCmnt? }
         #! type_designator = type-kw 1*spcCmnt / ":" spcCmnt?
         #> type-kw = "type"

--- a/spec/evaluate_member_rules_spec.rb
+++ b/spec/evaluate_member_rules_spec.rb
@@ -102,7 +102,7 @@ describe 'evaluate_member_rules' do
     tree = JCR.parse( '$mrule = `ab*` :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
-    e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", 2 ], JCR::EvalConditions.new( mapping, nil ) )
+    e = JCR.evaluate_rule( tree[0], tree[0], [ "abb", 2 ], JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_truthy
   end
 
@@ -112,6 +112,38 @@ describe 'evaluate_member_rules' do
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
     expect( e.success ).to be_falsey
+  end
+
+  it 'should fail a member with mismatch regex if name not suitably anchored and an integer' do
+    tree = JCR.parse( '$mrule = `ab.*` :integer' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], [ "xabc", 2 ], JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a member with regex with numbers and an integer' do
+    tree = JCR.parse( '$mrule = `ab\d*` :integer' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], [ "ab123", 2 ], JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
+  end
+
+  it 'should fail a member with mismatch regex if name not suitably anchored and an integer' do
+    tree = JCR.parse( '$mrule = `ab\d*` :integer' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], [ "ab123x", 2 ], JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_falsey
+  end
+
+  it 'should pass a member with empty regex and an integer matching any string' do
+    tree = JCR.parse( '$mrule = `` :integer' )
+    mapping = JCR.map_rule_names( tree )
+    JCR.check_rule_target_names( tree, mapping )
+    e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
+    expect( e.success ).to be_truthy
   end
 
   it 'should pass a member with mismatch regex and an integer with {not} annotation' do

--- a/spec/evaluate_member_rules_spec.rb
+++ b/spec/evaluate_member_rules_spec.rb
@@ -83,7 +83,7 @@ describe 'evaluate_member_rules' do
   #
 
   it 'should pass a member with regex and any value' do
-    tree = JCR.parse( '$mrule = /ab.*/ :any' )
+    tree = JCR.parse( '$mrule = `ab.*` :any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", "anything" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -91,7 +91,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with regex and any value with {not} annotation' do
-    tree = JCR.parse( '$mrule = @{not} /ab.*/ :any' )
+    tree = JCR.parse( '$mrule = @{not} `ab.*` :any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", "anything" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -99,7 +99,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should pass a member with regex and an integer' do
-    tree = JCR.parse( '$mrule = /ab*/ :integer' )
+    tree = JCR.parse( '$mrule = `ab*` :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -107,7 +107,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with mismatch regex and an integer' do
-    tree = JCR.parse( '$mrule = /ab.*/ :integer' )
+    tree = JCR.parse( '$mrule = `ab.*` :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -115,7 +115,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should pass a member with mismatch regex and an integer with {not} annotation' do
-    tree = JCR.parse( '$mrule = @{not} /ab.*/ :integer' )
+    tree = JCR.parse( '$mrule = @{not} `ab.*` :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -123,7 +123,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with regex and an integer against member with string' do
-    tree = JCR.parse( '$mrule = /ab.*/ :integer' )
+    tree = JCR.parse( '$mrule = `ab.*` :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", "a string" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -131,7 +131,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with mismatch regex and an integer against member with string' do
-    tree = JCR.parse( '$mrule = /ab.*/ :integer' )
+    tree = JCR.parse( '$mrule = `ab.*` :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", "a string" ], JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_object_rules_spec.rb
+++ b/spec/evaluate_object_rules_spec.rb
@@ -155,7 +155,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string twice' do
-    tree = JCR.parse( '$trule=: { /m.*/ :string *2..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*` :string *2..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -163,7 +163,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or twice' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *1..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -171,7 +171,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with three strings against an object rule with string member 0..2 step 2' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *0..2%2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *0..2%2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -179,7 +179,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member 0..4 step 2' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *0..4%2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *0..4%2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -187,7 +187,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with two strings against an object rule with string member 1..6 step 3' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *1..6%3 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *1..6%3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -195,7 +195,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or twice or thrice' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *1..3 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *1..3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -203,7 +203,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member once or twice' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *1..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -211,7 +211,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member default or twice' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -219,7 +219,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an empty object  against an object rule with string member default or twice' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {}, JCR::EvalConditions.new( mapping, nil ) )
@@ -227,7 +227,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member once or default' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *1.. }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *1.. }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -235,7 +235,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or default' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *1.. }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *1.. }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -243,7 +243,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member one or more' do
-    tree = JCR.parse( '$trule=: { /m.*/:string + }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -251,7 +251,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string member once or twice (ignore extras)' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *1..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing","m2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -259,7 +259,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string member default or twice (ignore extras)' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -275,7 +275,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with a string against an object rule with string twice' do
-    tree = JCR.parse( '$trule=: { /m.*/:string *2..2 }' )
+    tree = JCR.parse( '$trule=: { `m.*`:string *2..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -283,7 +283,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *1..2, /i.*/:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing", "i1"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -291,7 +291,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string*1..2, /i.*/:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string*1..2, `i.*`:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -299,7 +299,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string and two integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *1..2, /i.*/:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -307,7 +307,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two string and two integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *1..2, /i.*/:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -315,7 +315,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *1..2, /i.*/:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -323,7 +323,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string and three integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *1..2, /i.*/:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","i1"=> 1,"i2"=> 2,"i3"=> 3 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -331,7 +331,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 1*2 and any 1*2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *1..2, /.*/:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `.*`:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -339,7 +339,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *2, /.*/:integer *2 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *2, `.*`:integer *2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -347,7 +347,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string + and any +' do
-    tree = JCR.parse( '$trule=: { /s.*/:string +, /.*/:integer + }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string +, `.*`:integer + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -355,7 +355,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string ? and any ?' do
-    tree = JCR.parse( '$trule=: { /s.*/:string ?, /.*/:integer ? }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string ?, `.*`:integer ? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -363,7 +363,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one strings and one integers against an object rule with string ? and any ?' do
-    tree = JCR.parse( '$trule=: { /s.*/:string ?, /.*/:integer ? }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string ?, `.*`:integer ? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","1"=> 1 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -371,7 +371,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with two members against an object rule with overlapping rules' do
-    tree = JCR.parse( '$trule=: { /.*/:any *2, /.*/:any *1 }' )
+    tree = JCR.parse( '$trule=: { `.*`:any *2, `.*`:any *1 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","1"=> 1 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -379,7 +379,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should ignore extra members in an object' do
-    tree = JCR.parse( '$trule=: { /s.*/:string *2, "foo":integer *1 }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string *2, "foo":integer *1 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2,"bar"=>"baz" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -387,7 +387,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should not ignore extra members in an object' do
-    tree = JCR.parse( '$trule=: { /s.*/:string*2, "foo":integer*1, @{not} /.*/:any+ }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string*2, "foo":integer*1, @{not} `.*`:any+ }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2,"bar"=>"baz" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -395,7 +395,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with not extra members using {not} annotation' do
-    tree = JCR.parse( '$trule=: { /s.*/:string*2, "foo":integer*1, @{not} /.*/:any ? }' )
+    tree = JCR.parse( '$trule=: { `s.*`:string*2, "foo":integer*1, @{not} `.*`:any ? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -443,7 +443,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 2 mems against a string member and 0..2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string ) *0..2 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -451,7 +451,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 2 mems against a string member and 1..2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string *1..2 ) }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string *1..2 ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -459,7 +459,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 3 mems against a string member and 0..2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string ) *0..2 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -467,7 +467,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 3 mems against a string member and 0..3 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string ) *0..3 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -475,7 +475,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 4 mems against a string member and 0..3 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string ) *0..3 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3","s4"=>"thing4" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -483,7 +483,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 3 mems against a string member and 0..4%2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string ) *0..4%2 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..4%2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -491,7 +491,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object w/ 3 mems against a string member and 0..6%3 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string *0..6%3 ) }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string *0..6%3 ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -499,7 +499,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object w/ 3 mems against a string member and 0..6%3 group member containing a string member', :focus => true do
-    tree = JCR.parse( '$trule=: { "s1":string, ( /s[2-9]/:string ) *0..6%3 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..6%3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -643,7 +643,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass a restricted object' do
-    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} // : any + }' )
+    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} `.*` : any + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"foo"=>1, "bar"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -651,7 +651,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an unrestricted object' do
-    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} // : any + }' )
+    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} `.*` : any + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"foo"=>1, "bar"=> 2, "baz" => 3 }, JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -471,6 +471,12 @@ describe 'parser' do
     expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
+  it 'should parse an any member rule of `` treated as `.*`' do
+    tree = JCR.parse( '$trule = `` : integer' )
+    expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq([])
+    expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
+  end
+
   it 'should parse an regex member rule with string value' do
     tree = JCR.parse( '$trule = `a.regex\\.goes.here.*` : string' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq("a.regex\\.goes.here.*")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -349,19 +349,19 @@ describe 'parser' do
   end
 
   it 'should parse an any member rule with integer value' do
-    tree = JCR.parse( '$trule = /.*/ : integer' )
+    tree = JCR.parse( '$trule = `.*` : integer' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq(".*")
     expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
-  it 'should parse an any member rule of //' do
-    tree = JCR.parse( '$trule = // : integer' )
-    expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq([])
+  it 'should parse an any member rule of `.*`' do
+    tree = JCR.parse( '$trule = `.*` : integer' )
+    expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq(".*")
     expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
   it 'should parse an regex member rule with string value' do
-    tree = JCR.parse( '$trule = /a.regex\\.goes.here.*/ : string' )
+    tree = JCR.parse( '$trule = `a.regex\\.goes.here.*` : string' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq("a.regex\\.goes.here.*")
     expect(tree[0][:rule][:member_rule][:primitive_rule][:string]).to eq("string")
   end
@@ -853,17 +853,17 @@ describe 'parser' do
   end
 
   it 'should parse a group rule with a member rule specified with a regex that has a value rule' do
-    tree = JCR.parse( '$trule = ( /.*/ : integer )' )
+    tree = JCR.parse( '$trule = ( `.*` : integer )' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse a group rule with a member rule specified with a regex and repetition that has a value rule' do
-    tree = JCR.parse( '$trule = ( /.*/ : integer *0..15 )' )
+    tree = JCR.parse( '$trule = ( `.*` : integer *0..15 )' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse a group rule with a member rule specified with a regex and only repetition min that has a value rule' do
-    tree = JCR.parse( '$trule = ( /.*/ : integer * 1.. )' )
+    tree = JCR.parse( '$trule = ( `.*` : integer * 1.. )' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
@@ -923,12 +923,12 @@ describe 'parser' do
   end
 
   it 'should parse a member regex rule with a comment' do
-    tree = JCR.parse( "$trule = /.*/ : $target_rule ;\;;\n" )
+    tree = JCR.parse( "$trule = `.*` : $target_rule ;\;;\n" )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse two rules on the same line' do
-    tree = JCR.parse( '$trule1 = :/.*/  $trule2 = /.*/ : $target_rule' )
+    tree = JCR.parse( '$trule1 = :/.*/  $trule2 = `.*` : $target_rule' )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
     expect(tree[1][:rule][:rule_name]).to eq("trule2")
   end
@@ -984,7 +984,7 @@ describe 'parser' do
 ;comment 3
 ;comment 4
 #jcr-version 4.0
-$trule2 =/.*/ :$target_rule
+$trule2 =`.*` :$target_rule
 EX
     tree = JCR.parse( ex )
     expect(tree[1][:rule][:rule_name]).to eq("trule2")
@@ -997,7 +997,7 @@ $trule1= type /.*/
 ;comment 2
 ;comment 3
 ;comment 4
-$trule2 =/.*/ :$target_rule
+$trule2 =`.*` :$target_rule
 EX
     tree = JCR.parse( ex )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
@@ -1011,7 +1011,7 @@ $trule1
 	;comment 2
 	=:
 /.*/
-$trule2 = /.*/: $target_rule
+$trule2 = `.*`: $target_rule
 EX
     tree = JCR.parse( ex )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
@@ -1415,7 +1415,7 @@ EX8
 
   it 'should parse ex4 from I-D' do
     ex9 = <<EX9
-$any_member = /.*/ : any
+$any_member = `.*` : any
 
 $object_of_anything =: { $any_member* }
 EX9
@@ -1425,7 +1425,7 @@ EX9
 
   it 'should parse ex5 from I-D' do
     ex10 = <<EX10
-$object_of_anything = :{ /.*/:any* }
+$object_of_anything = :{ `.*`:any* }
 EX10
     tree = JCR.parse( ex10 )
     expect(tree[0][:rule][:rule_name]).to eq("object_of_anything")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -54,6 +54,11 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
   end
 
+  it 'should parse an ipv4 value defintion 4' do
+    tree = JCR.parse( '$trule = ipv4 ' )
+    expect(tree[0][:rule][:primitive_rule][:ipv4]).to eq("ipv4")
+  end
+
   it 'should parse an ipv6 value defintion 1' do
     tree = JCR.parse( '$trule = type ipv6' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
@@ -104,6 +109,12 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
   end
 
+  it 'should parse a single quoted string constant without leading colon' do
+    tree = JCR.parse( "$trule = 'a string constant'" )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
+  end
+
   it 'should parse a string' do
     tree = JCR.parse( '$trule = type string' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
@@ -112,6 +123,12 @@ describe 'parser' do
 
   it 'should parse a regex 1' do
     tree = JCR.parse( '$trule = type /a.regex.goes.here.*/' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex.goes.here.*")
+  end
+
+  it 'should parse a regex without leading colon' do
+    tree = JCR.parse( '$trule = /a.regex.goes.here.*/' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
     expect(tree[0][:rule][:primitive_rule][:regex]).to eq("a.regex.goes.here.*")
   end
@@ -160,6 +177,11 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:uri]).to eq("uri")
   end
 
+  it 'should parse a uri without type keyword' do
+    tree = JCR.parse( '$trule = uri' )
+    expect(tree[0][:rule][:primitive_rule][:uri]).to eq("uri")
+  end
+
   it 'should parse a uri scheme' do
     tree = JCR.parse( '$trule = type uri..http' )
     expect(tree[0][:rule][:primitive_rule][:uri][:uri_scheme]).to eq("http")
@@ -189,6 +211,11 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:boolean_v]).to eq("boolean")
   end
 
+  it 'should parse boolean without type keyword' do
+    tree = JCR.parse( '$trule = boolean' )
+    expect(tree[0][:rule][:primitive_rule][:boolean_v]).to eq("boolean")
+  end
+
   it 'should parse null' do
     tree = JCR.parse( '$trule = type null' )
     expect(tree[0][:rule][:primitive_rule][:null]).to eq("null")
@@ -199,8 +226,18 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
+  it 'should parse a integer value without a range without type keyword' do
+    tree = JCR.parse( '$trule = integer' )
+    expect(tree[0][:rule][:primitive_rule][:integer_v]).to eq("integer")
+  end
+
   it 'should parse a integer constant' do
     tree = JCR.parse( '$trule = type 2' )
+    expect(tree[0][:rule][:primitive_rule][:integer]).to eq("2")
+  end
+
+  it 'should parse a integer constant without type keyword' do
+    tree = JCR.parse( '$trule = 2' )
     expect(tree[0][:rule][:primitive_rule][:integer]).to eq("2")
   end
 
@@ -209,8 +246,19 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:integer]).to eq("-2")
   end
 
+  it 'should parse a negative integer constant without : prefix' do
+    tree = JCR.parse( '$trule = -2' )
+    expect(tree[0][:rule][:primitive_rule][:integer]).to eq("-2")
+  end
+
   it 'should parse an integer full range' do
     tree = JCR.parse( '$trule = :0..100' )
+    expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
+  end
+
+  it 'should parse an integer full range without : prefix' do
+    tree = JCR.parse( '$trule = 0..100' )
     expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
@@ -227,8 +275,19 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-1")
   end
 
+  it 'should parse a negative integer full range without : prefix' do
+    tree = JCR.parse( '$trule = -100..-1' )
+    expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("-100")
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-1")
+  end
+
   it 'should parse an integer range with a min range' do
     tree = JCR.parse( '$trule = :0..' )
+    expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
+  end
+
+  it 'should parse an integer range with a min range without : prefix' do
+    tree = JCR.parse( '$trule = 0..' )
     expect(tree[0][:rule][:primitive_rule][:integer_min]).to eq("0")
   end
 
@@ -237,13 +296,28 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
   end
 
+  it 'should parse an integer rangge with a max range without : prefix' do
+    tree = JCR.parse( '$trule = ..100' )
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("100")
+  end
+
   it 'should parse a negative integer range with a max range' do
     tree = JCR.parse( '$trule = :..-100' )
     expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-100")
   end
 
+  it 'should parse a negative integer range with a max range without : prefix' do
+    tree = JCR.parse( '$trule = ..-100' )
+    expect(tree[0][:rule][:primitive_rule][:integer_max]).to eq("-100")
+  end
+
   it 'should parse a sized int value without a range' do
     tree = JCR.parse( '$trule = :int32' )
+    expect(tree[0][:rule][:primitive_rule][:sized_int_v][:bits]).to eq("32")
+  end
+
+  it 'should parse a sized int value without a range without : prefix' do
+    tree = JCR.parse( '$trule = int32' )
     expect(tree[0][:rule][:primitive_rule][:sized_int_v][:bits]).to eq("32")
   end
 
@@ -257,6 +331,11 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:double_v]).to eq("double")
   end
 
+  it 'should parse a double value without : prefix' do
+    tree = JCR.parse( '$trule = double' )
+    expect(tree[0][:rule][:primitive_rule][:double_v]).to eq("double")
+  end
+
   it 'should parse a float value' do
     tree = JCR.parse( '$trule = :float' )
     expect(tree[0][:rule][:primitive_rule][:float_v]).to eq("float")
@@ -267,13 +346,29 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:float]).to eq("2.0")
   end
 
+  it 'should parse a float constant without : prefix' do
+    tree = JCR.parse( '$trule = 2.0' )
+    expect(tree[0][:rule][:primitive_rule][:float]).to eq("2.0")
+  end
+
   it 'should parse a negative float constant' do
     tree = JCR.parse( '$trule = :-2.0' )
     expect(tree[0][:rule][:primitive_rule][:float]).to eq("-2.0")
   end
 
+  it 'should parse a negative float constant without : prefix' do
+    tree = JCR.parse( '$trule = -2.0' )
+    expect(tree[0][:rule][:primitive_rule][:float]).to eq("-2.0")
+  end
+
   it 'should parse a float range with a full range' do
     tree = JCR.parse( '$trule = :0.0..100.0' )
+    expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.0")
+    expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.0")
+  end
+
+  it 'should parse a float range with a full range without : prefix' do
+    tree = JCR.parse( '$trule = 0.0..100.0' )
     expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.0")
     expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.0")
   end
@@ -289,8 +384,18 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.3939")
   end
 
+  it 'should parse a float range with a min range without : prefix' do
+    tree = JCR.parse( '$trule = 0.3939..' )
+    expect(tree[0][:rule][:primitive_rule][:float_min]).to eq("0.3939")
+  end
+
   it 'should parse a float range with a max range' do
     tree = JCR.parse( '$trule = :..100.003' )
+    expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.003")
+  end
+
+  it 'should parse a float range with a max range without : prefix' do
+    tree = JCR.parse( '$trule = ..100.003' )
     expect(tree[0][:rule][:primitive_rule][:float_max]).to eq("100.003")
   end
 
@@ -328,6 +433,12 @@ describe 'parser' do
 
   it 'should parse two rules' do
     tree = JCR.parse( '$vrule = :integer $mrule ="thing": $vrule' )
+    expect(tree[0][:rule][:rule_name]).to eq("vrule")
+    expect(tree[1][:rule][:rule_name]).to eq("mrule")
+  end
+
+  it 'should parse two rules without : prefix' do
+    tree = JCR.parse( '$vrule = integer $mrule ="thing": $vrule' )
     expect(tree[0][:rule][:rule_name]).to eq("vrule")
     expect(tree[1][:rule][:rule_name]).to eq("mrule")
   end
@@ -929,6 +1040,12 @@ describe 'parser' do
 
   it 'should parse two rules on the same line' do
     tree = JCR.parse( '$trule1 = :/.*/  $trule2 = `.*` : $target_rule' )
+    expect(tree[0][:rule][:rule_name]).to eq("trule1")
+    expect(tree[1][:rule][:rule_name]).to eq("trule2")
+  end
+
+  it 'should parse two rules on the same line without : prefix' do
+    tree = JCR.parse( '$trule1 = /.*/  $trule2 = `.*` : $target_rule' )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
     expect(tree[1][:rule][:rule_name]).to eq("trule2")
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -92,6 +92,18 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
   end
 
+  it 'should parse a single quoted string constant' do
+    tree = JCR.parse( "$trule = type 'a string constant'" )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
+  end
+
+  it 'should parse a single quoted string constant' do
+    tree = JCR.parse( "$trule = :'a string constant'" )
+    expect(tree[0][:rule][:rule_name]).to eq("trule")
+    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
+  end
+
   it 'should parse a string' do
     tree = JCR.parse( '$trule = type string' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")


### PR DESCRIPTION
These is the changes to allow `$rule = integer` instead of `$rule = : integer`.

I've gone with the idea that, unlike regex-values, member-regexs are implicitly anchored, and changed evaluate_member_rules.rb accordingly.  So `` `p\d+` `` matches `"p1"` but not `"xp1"`.  That feels sensible to me.

HOWEVER, as this would require the "any name" wildcard to be `` `.*` ``, (which seems verbose for possibly the most common use-case of wildcard names), I've allowed ``` `` ``` to represent any name, rather than just the empty string name (i.e. the empty pattern is not anchored).  This seems OK as, to specify only the empty string as a name, you can do `""`.

But we can change this if you think we should.