### PR TITLE
Reinserted accidentally deleted \ into q-string escape-codes

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -201,9 +201,10 @@ char             = unescaped /
                    escape (
                    quotation-mark /
                    escape-codes )
-unescaped        = %x20-21 / %x23-5B / %x5D-10FFFF
+unescaped        = %x20-21 / %x23-5B / %x5D-10FFFF ; Not " or \
 escape           = %x5C              ; \
 escape-codes     = 
+                   %x5C /          ; \    reverse solidus U+005C
                    %x2F /          ; /    solidus         U+002F
                    %x62 /          ; b    backspace       U+0008
                    %x66 /          ; f    form feed       U+000C

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -430,9 +430,10 @@ module JCR
         #!   escape (
         #!     quotation-mark /
         #!     escape_codes )
-        #! unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+        #! unescaped = %x20-21 / %x23-5B / %x5D-10FFFF ; Not " or \
         #! escape = %x5C              ; \
         #! escape_codes =
+        #!   %x5C /          ; \    reverse solidus U+005C
         #!   %x2F /          ; /    solidus         U+002F
         #!   %x62 /          ; b    backspace       U+0008
         #!   %x66 /          ; f    form feed       U+000C


### PR DESCRIPTION
This is embarrassing!

Seems I accidentally deleted the \ escape code when accommodating singly quoted strings.

The Parslet code is more liberal than the ABNF (the ABNF being derived from the JSON RFC), so tests don't highlight this.