### PR TITLE
Deprecate colon

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -64,7 +64,7 @@ rule-def-type-rule = value-rule / type-choice
 value-rule       = primitive-rule / array-rule / object-rule
 member-rule      = annotations
                    member-name-spec *sp-cmt ":" *sp-cmt type-rule
-member-name-spec = backtick-regex / q-string
+member-name-spec = regex / q-string
 type-rule        = value-rule / type-choice / target-rule-name
 type-choice      = annotations "(" type-choice-items
                    *( choice-combiner type-choice-items ) ")"
@@ -83,7 +83,7 @@ annotation-name  = name
 annotation-parameters = multi-line-parameters
 
 primitive-rule   = annotations primitive-def
-primitive-def    = string-type / string-range / string-value1 / string-value2 /
+primitive-def    = string-type / string-range / string-value /
                    null-type / boolean-type / true-value /
                    false-value / double-type / float-type /
                    float-range / float-value /
@@ -99,8 +99,7 @@ boolean-type     = boolean-kw
 true-value       = true-kw
 false-value      = false-kw
 string-type      = string-kw
-string-value1    = sq-string
-string-value2    = q-string
+string-value     = q-string
 string-range     = regex
 double-type      = double-kw
 float-type       = float-kw
@@ -194,16 +193,11 @@ exp              = e [ minus / plus ] 1*DIGIT
 e                = %x65 / %x45                   ; e E
 zero             = %x30                          ; 0
 
-q-string         = quotation-mark *char quotation-mark
-                   ; Derive from RFC 7159
-quotation-mark   = %x22      ; "    quotation mark  U+0022
+q-string         = quotation-mark *char quotation-mark 
+                   ; From RFC 7159
 char             = unescaped /
                    escape (
-                   quotation-mark /
-                   escape-code )
-unescaped        = %x20-21 / %x23-5B / %x5D-10FFFF ; Not " or \
-escape           = %x5C              ; \
-escape-code      = 
+                   %x22 /          ; "    quotation mark  U+0022
                    %x5C /          ; \    reverse solidus U+005C
                    %x2F /          ; /    solidus         U+002F
                    %x62 /          ; b    backspace       U+0008
@@ -211,15 +205,10 @@ escape-code      =
                    %x6E /          ; n    line feed       U+000A
                    %x72 /          ; r    carriage return U+000D
                    %x74 /          ; t    tab             U+0009
-                   %x75 4HEXDIG    ; uXXXX                U+XXXX
-
-sq-string        = single-quote-mark *sq-char single-quote-mark
-single-quote-mark = %x27      ; '    single quotation mark  U+0027
-sq-char          = sq-unescaped /
-                   escape (
-                   single-quote-mark /
-                   escape-code )
-sq-unescaped     = %x20-26 / %x28-5B / %x5D-10FFFF ; Not ' or \
+                   %x75 4HEXDIG )  ; uXXXX                U+XXXX
+escape           = %x5C              ; \
+quotation-mark   = %x22      ; "
+unescaped        = %x20-21 / %x23-5B / %x5D-10FFFF
 
 regex            = "/" *( escape re-escape-code / not-slash ) "/"
                    [ regex-modifiers ]
@@ -228,9 +217,6 @@ not-slash        = HTAB / CR / LF / %x20-2E / %x30-10FFFF
                    ; Any char except "/"
 regex-modifiers  = *( "i" / "s" / "x" )
 
-backtick-regex   = "`" *( escape re-escape-code / not-backtick ) "`"
-not-backtick     = HTAB / CR / LF / %x20-5F / %x61-10FFFF
-                   ; Any char except "`"
 uri-scheme       = 1*ALPHA
 
 ;; Keywords

--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -68,7 +68,6 @@ member-name-spec = regex / q-string
 type-rule        = value-rule / type-choice / target-rule-name
 type-choice      = annotations "(" type-choice-items
                    *( choice-combiner type-choice-items ) ")"
-explicit-type-choice = type-designator type-choice
 type-choice-items = *sp-cmt ( type-choice / type-rule ) *sp-cmt
 
 annotations      = *( "@{" *sp-cmt annotation-set *sp-cmt "}"
@@ -145,15 +144,14 @@ array-rule       = annotations "[" *sp-cmt [ array-items *sp-cmt ] "]"
 array-items      = array-item [ 1*( sequence-combiner array-item ) /
                    1*( choice-combiner array-item ) ]
 array-item       = array-item-types *sp-cmt [ repetition *sp-cmt ]
-array-item-types = array-group / type-rule / explicit-type-choice
+array-item-types = array-group / type-rule
 array-group      = annotations "(" *sp-cmt [ array-items *sp-cmt ] ")"
 
 group-rule       = annotations "(" *sp-cmt [ group-items *sp-cmt ] ")"
 group-items      = group-item [ 1*( sequence-combiner group-item ) /
                    1*( choice-combiner group-item ) ]
 group-item       = group-item-types *sp-cmt [ repetition *sp-cmt ]
-group-item-types = group-group / member-rule /
-                   type-rule / explicit-type-choice
+group-item-types = group-group / member-rule / type-rule
 group-group      = group-rule
 
 sequence-combiner = "," *sp-cmt

--- a/lib/jcr/evaluate_member_rules.rb
+++ b/lib/jcr/evaluate_member_rules.rb
@@ -60,7 +60,7 @@ module JCR
         match_spec = Regexp.new( "" )
         trace( econs, "Noting empty regular expression." )
       else
-        match_spec = Regexp.new( "^#{rule[:member_regex][:regex].to_s}$" )
+        match_spec = Regexp.new( rule[:member_regex][:regex].to_s )
       end
       if match_spec =~ data[ 0 ]
         member_match = true

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -149,8 +149,6 @@ module JCR
     rule(:type_choice)       { ( annotations >> str('(') >> type_choice_items >> ( choice_combiner >> type_choice_items ).repeat >> str(')') ).as(:group_rule) }
         #! type_choice = annotations "(" type_choice_items
         #!               *( choice_combiner type_choice_items ) ")"
-    rule(:explicit_type_choice) { type_designator >> type_choice }
-        #! explicit_type_choice = type_designator type_choice
     rule(:type_choice_items) { spcCmnt? >> (type_choice | type_rule) >> spcCmnt? }
         #! type_choice_items = spcCmnt? ( type_choice / type_rule ) spcCmnt?
         #!
@@ -332,8 +330,8 @@ module JCR
         #!                           1*( choice_combiner array_item ) ]
     rule(:array_item)   { array_item_types >> spcCmnt? >> ( repetition >> spcCmnt? ).maybe }
         #! array_item = array_item_types spcCmnt? [ repetition spcCmnt? ]
-    rule(:array_item_types) { array_group | type_rule | explicit_type_choice }
-        #! array_item_types = array_group / type_rule / explicit_type_choice
+    rule(:array_item_types) { array_group | type_rule }
+        #! array_item_types = array_group / type_rule
     rule(:array_group)  { ( annotations >> str('(') >> spcCmnt? >> array_items.maybe >> spcCmnt? >> str(')') ).as(:group_rule) }
         #! array_group = annotations "(" spcCmnt? [ array_items spcCmnt? ] ")"
         #!
@@ -346,9 +344,8 @@ module JCR
         #!                           1*( choice_combiner group_item ) ]
     rule(:group_item)   { group_item_types >> spcCmnt? >> ( repetition >> spcCmnt? ).maybe }
         #! group_item = group_item_types spcCmnt? [ repetition spcCmnt? ]
-    rule(:group_item_types) { group_group | member_rule | type_rule | explicit_type_choice }
-        #! group_item_types = group_group / member_rule /
-        #!                    type_rule / explicit_type_choice
+    rule(:group_item_types) { group_group | member_rule | type_rule }
+        #! group_item_types = group_group / member_rule / type_rule
     rule(:group_group)  { group_rule }
         #! group_group = group_rule
         #!

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -142,8 +142,8 @@ module JCR
     rule(:member_rule)       { ( annotations >> member_name_spec >> spcCmnt? >> str(':') >> spcCmnt? >> type_rule ).as(:member_rule) }
         #! member_rule = annotations
         #!               member_name_spec spcCmnt? ":" spcCmnt? type_rule
-    rule(:member_name_spec)  { backtick_regex.as(:member_regex) | q_string.as(:member_name) }
-        #! member_name_spec = backtick_regex / q_string
+    rule(:member_name_spec)  { regex.as(:member_regex) | q_string.as(:member_name) }
+        #! member_name_spec = regex / q_string
     rule(:type_rule)         { value_rule | type_choice | target_rule_name }
         #! type_rule = value_rule / type_choice / target_rule_name
     rule(:type_choice)       { ( annotations >> str('(') >> type_choice_items >> ( choice_combiner >> type_choice_items ).repeat >> str(')') ).as(:group_rule) }
@@ -181,7 +181,7 @@ module JCR
         #! primitive_rule = annotations primitive_def
 
     rule(:primitive_def) {
-          string_type | string_range | string_value1 | string_value2 |
+          string_type | string_range | string_value |
           null_type | boolean_type | true_value | false_value |
           double_type | float_type | float_range | float_value |
           integer_type | integer_range | integer_value |
@@ -192,7 +192,7 @@ module JCR
           hex_type | base32hex_type | base32_type | base64url_type | base64_type |
           any
     }
-        #! primitive_def = string_type / string_range / string_value1 / string_value2 /
+        #! primitive_def = string_type / string_range / string_value /
         #!             null_type / boolean_type / true_value /
         #!             false_value / double_type / float_type /
         #!             float_range / float_value /
@@ -218,10 +218,8 @@ module JCR
     rule(:string_type)    { str('string').as(:string) }
         #! string_type = string-kw
         #> string-kw = "string"
-    rule(:string_value1)    { sq_string }
-        #! string_value1 = sq_string
-    rule(:string_value2)    { q_string }
-        #! string_value2 = q_string
+    rule(:string_value)    { q_string }
+        #! string_value = q_string
     rule(:string_range)    { regex }
         #! string_range = regex
     rule(:double_type)     { str('double').as(:double_v) }
@@ -416,23 +414,16 @@ module JCR
         #! zero          = %x30                          ; 0
         #!
 
-    rule(:q_string)  { # (Double) quoted string
+    rule(:q_string)  {
       str('"') >>
-        # ( str('\\') >> match('[^\r\n]') | str('"').absent? >> match('[^\r\n]') ).repeat.as(:q_string) >>
         ( match('\.') | match('[^"]') ).repeat.as(:q_string) >>
       str('"')
     }
-
-        #! q_string = quotation-mark *char quotation-mark
-        #!            ; Derive from RFC 7159
-        #! quotation-mark = %x22      ; "    quotation mark  U+0022
+        #! q_string = quotation-mark *char quotation-mark 
+        #!            ; From RFC 7159
         #! char = unescaped /
         #!   escape (
-        #!     quotation-mark /
-        #!     escape_code )
-        #! unescaped = %x20-21 / %x23-5B / %x5D-10FFFF ; Not " or \
-        #! escape = %x5C              ; \
-        #! escape_code =
+        #!   %x22 /          ; "    quotation mark  U+0022
         #!   %x5C /          ; \    reverse solidus U+005C
         #!   %x2F /          ; /    solidus         U+002F
         #!   %x62 /          ; b    backspace       U+0008
@@ -440,22 +431,10 @@ module JCR
         #!   %x6E /          ; n    line feed       U+000A
         #!   %x72 /          ; r    carriage return U+000D
         #!   %x74 /          ; t    tab             U+0009
-        #!   %x75 4HEXDIG    ; uXXXX                U+XXXX
-        #!
-
-    rule(:sq_string)  { # Single quoted string
-      str("'") >>
-        ( str('\\') >> match('[^\r\n]') | str("'").absent? >> match('[^\r\n]') ).repeat.as(:q_string) >>
-      str("'")
-    }
-
-        #! sq_string = single-quote-mark *sq_char single-quote-mark
-        #! single-quote-mark = %x27      ; '    single quotation mark  U+0027
-        #! sq_char = sq_unescaped /
-        #!   escape (
-        #!     single-quote-mark /
-        #!     escape_code )
-        #! sq_unescaped = %x20-26 / %x28-5B / %x5D-10FFFF ; Not ' or \
+        #!   %x75 4HEXDIG )  ; uXXXX                U+XXXX
+        #! escape = %x5C              ; \
+        #! quotation-mark = %x22      ; "
+        #! unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
         #!
 
     rule(:regex)     { str('/') >> (str('\\/') | match('[^/]+')).repeat.as(:regex) >> str('/') >> regex_modifiers.maybe }
@@ -467,11 +446,6 @@ module JCR
     rule(:regex_modifiers) { match('[isx]').repeat.as(:regex_modifiers) }
         #! regex_modifiers = *( "i" / "s" / "x" )
         #!
-
-    rule(:backtick_regex)     { str('`') >> (str('\\`') | match('[^`]+')).repeat.as(:regex) >> str('`') }
-        #! backtick_regex = "`" *( escape re_escape_code / not-backtick ) "`"
-        #! not-backtick = HTAB / CR / LF / %x20-5F / %x61-10FFFF
-        #!             ; Any char except "`"
 
     rule(:uri_scheme) { ( match('[a-zA-Z]').repeat(1) ).as(:uri_scheme) }
         #! uri_scheme = 1*ALPHA

--- a/spec/evaluate_member_rules_spec.rb
+++ b/spec/evaluate_member_rules_spec.rb
@@ -83,7 +83,7 @@ describe 'evaluate_member_rules' do
   #
 
   it 'should pass a member with regex and any value' do
-    tree = JCR.parse( '$mrule = `ab.*` :any' )
+    tree = JCR.parse( '$mrule = /^ab.*/ :any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", "anything" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -91,7 +91,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with regex and any value with {not} annotation' do
-    tree = JCR.parse( '$mrule = @{not} `ab.*` :any' )
+    tree = JCR.parse( '$mrule = @{not} /^ab.*/ :any' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", "anything" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -99,7 +99,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should pass a member with regex and an integer' do
-    tree = JCR.parse( '$mrule = `ab*` :integer' )
+    tree = JCR.parse( '$mrule = /^ab*$/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abb", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -107,7 +107,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with mismatch regex and an integer' do
-    tree = JCR.parse( '$mrule = `ab.*` :integer' )
+    tree = JCR.parse( '$mrule = /^ab.*/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -115,7 +115,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with mismatch regex if name not suitably anchored and an integer' do
-    tree = JCR.parse( '$mrule = `ab.*` :integer' )
+    tree = JCR.parse( '$mrule = /^ab.*/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "xabc", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -123,7 +123,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should pass a member with regex with numbers and an integer' do
-    tree = JCR.parse( '$mrule = `ab\d*` :integer' )
+    tree = JCR.parse( '$mrule = /ab\d*$/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "ab123", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -131,7 +131,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with mismatch regex if name not suitably anchored and an integer' do
-    tree = JCR.parse( '$mrule = `ab\d*` :integer' )
+    tree = JCR.parse( '$mrule = /ab\d*$/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "ab123x", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -139,7 +139,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should pass a member with empty regex and an integer matching any string' do
-    tree = JCR.parse( '$mrule = `` :integer' )
+    tree = JCR.parse( '$mrule = // :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -147,7 +147,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should pass a member with mismatch regex and an integer with {not} annotation' do
-    tree = JCR.parse( '$mrule = @{not} `ab.*` :integer' )
+    tree = JCR.parse( '$mrule = @{not} /^ab.*/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", 2 ], JCR::EvalConditions.new( mapping, nil ) )
@@ -155,7 +155,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with regex and an integer against member with string' do
-    tree = JCR.parse( '$mrule = `ab.*` :integer' )
+    tree = JCR.parse( '$mrule = /^ab.*/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "abc", "a string" ], JCR::EvalConditions.new( mapping, nil ) )
@@ -163,7 +163,7 @@ describe 'evaluate_member_rules' do
   end
 
   it 'should fail a member with mismatch regex and an integer against member with string' do
-    tree = JCR.parse( '$mrule = `ab.*` :integer' )
+    tree = JCR.parse( '$mrule = /^ab.*/ :integer' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], [ "blah", "a string" ], JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/evaluate_object_rules_spec.rb
+++ b/spec/evaluate_object_rules_spec.rb
@@ -155,7 +155,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string twice' do
-    tree = JCR.parse( '$trule=: { `m.*` :string *2..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/ :string *2..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -163,7 +163,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or twice' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -171,7 +171,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with three strings against an object rule with string member 0..2 step 2' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *0..2%2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *0..2%2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -179,7 +179,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member 0..4 step 2' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *0..4%2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *0..4%2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -187,7 +187,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with two strings against an object rule with string member 1..6 step 3' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *1..6%3 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *1..6%3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2"}, JCR::EvalConditions.new( mapping, nil ) )
@@ -195,7 +195,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or twice or thrice' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *1..3 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *1..3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing","m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -203,7 +203,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member once or twice' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=>"thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -211,7 +211,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member default or twice' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -219,7 +219,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an empty object  against an object rule with string member default or twice' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {}, JCR::EvalConditions.new( mapping, nil ) )
@@ -227,7 +227,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string against an object rule with string member once or default' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *1.. }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *1.. }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -235,7 +235,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member once or default' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *1.. }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *1.. }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -243,7 +243,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings against an object rule with string member one or more' do
-    tree = JCR.parse( '$trule=: { `m.*`:string + }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -251,7 +251,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string member once or twice (ignore extras)' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing","m2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -259,7 +259,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string member default or twice (ignore extras)' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing", "m2"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -275,7 +275,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with a string against an object rule with string twice' do
-    tree = JCR.parse( '$trule=: { `m.*`:string *2..2 }' )
+    tree = JCR.parse( '$trule=: { /^m.*/:string *2..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"m1"=> "thing" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -283,7 +283,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with a string and integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *1..2, /^i.*/:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing", "i1"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -291,7 +291,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string*1..2, `i.*`:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string*1..2, /^i.*/:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -299,7 +299,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string and two integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *1..2, /^i.*/:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -307,7 +307,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two string and two integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *1..2, /^i.*/:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -315,7 +315,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *1..2, /^i.*/:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","i1"=> 1,"i2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -323,7 +323,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one string and three integer against an object rule with string 1*2 and integer 1*2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `i.*`:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *1..2, /^i.*/:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","i1"=> 1,"i2"=> 2,"i3"=> 3 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -331,7 +331,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 1*2 and any 1*2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *1..2, `.*`:integer *1..2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *1..2, //:integer *1..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -339,7 +339,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string 2 and any 2' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *2, `.*`:integer *2 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *2, //:integer *2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -347,7 +347,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string + and any +' do
-    tree = JCR.parse( '$trule=: { `s.*`:string +, `.*`:integer + }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string +, //:integer + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -355,7 +355,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with two strings and two integers against an object rule with string ? and any ?' do
-    tree = JCR.parse( '$trule=: { `s.*`:string ?, `.*`:integer ? }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string ?, //:integer ? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=> "thing2","1"=> 1,"2"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -363,7 +363,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass an object with one strings and one integers against an object rule with string ? and any ?' do
-    tree = JCR.parse( '$trule=: { `s.*`:string ?, `.*`:integer ? }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string ?, //:integer ? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","1"=> 1 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -371,7 +371,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an object with two members against an object rule with overlapping rules' do
-    tree = JCR.parse( '$trule=: { `.*`:any *2, `.*`:any *1 }' )
+    tree = JCR.parse( '$trule=: { //:any *2, //:any *1 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","1"=> 1 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -379,7 +379,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should ignore extra members in an object' do
-    tree = JCR.parse( '$trule=: { `s.*`:string *2, "foo":integer *1 }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string *2, "foo":integer *1 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2,"bar"=>"baz" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -387,7 +387,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should not ignore extra members in an object' do
-    tree = JCR.parse( '$trule=: { `s.*`:string*2, "foo":integer*1, @{not} `.*`:any+ }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string*2, "foo":integer*1, @{not} //:any+ }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2,"bar"=>"baz" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -395,7 +395,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object with not extra members using {not} annotation' do
-    tree = JCR.parse( '$trule=: { `s.*`:string*2, "foo":integer*1, @{not} `.*`:any ? }' )
+    tree = JCR.parse( '$trule=: { /^s.*/:string*2, "foo":integer*1, @{not} //:any ? }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","foo"=>2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -443,7 +443,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 2 mems against a string member and 0..2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..2 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string ) *0..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -451,7 +451,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 2 mems against a string member and 1..2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string *1..2 ) }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string *1..2 ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -459,7 +459,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 3 mems against a string member and 0..2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..2 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string ) *0..2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -467,7 +467,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 3 mems against a string member and 0..3 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..3 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string ) *0..3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -475,7 +475,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 4 mems against a string member and 0..3 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..3 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string ) *0..3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3","s4"=>"thing4" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -483,7 +483,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass object w/ 3 mems against a string member and 0..4%2 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..4%2 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string ) *0..4%2 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -491,7 +491,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object w/ 3 mems against a string member and 0..6%3 group member containing a string member' do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string *0..6%3 ) }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string *0..6%3 ) }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -499,7 +499,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail object w/ 3 mems against a string member and 0..6%3 group member containing a string member', :focus => true do
-    tree = JCR.parse( '$trule=: { "s1":string, ( `s[2-9]`:string ) *0..6%3 }' )
+    tree = JCR.parse( '$trule=: { "s1":string, ( /^s[2-9]$/:string ) *0..6%3 }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"s1"=> "thing","s2"=>"thing2","s3"=>"thing3" }, JCR::EvalConditions.new( mapping, nil ) )
@@ -643,7 +643,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should pass a restricted object' do
-    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} `.*` : any + }' )
+    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} // : any + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"foo"=>1, "bar"=> 2 }, JCR::EvalConditions.new( mapping, nil ) )
@@ -651,7 +651,7 @@ describe 'evaluate_object_rules' do
   end
 
   it 'should fail an unrestricted object' do
-    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} `.*` : any + }' )
+    tree = JCR.parse( '$orule = { "foo" : 1, "bar" : 2, @{not} // : any + }' )
     mapping = JCR.map_rule_names( tree )
     JCR.check_rule_target_names( tree, mapping )
     e = JCR.evaluate_rule( tree[0], tree[0], {"foo"=>1, "bar"=> 2, "baz" => 3 }, JCR::EvalConditions.new( mapping, nil ) )

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -97,24 +97,6 @@ describe 'parser' do
     expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
   end
 
-  it 'should parse a single quoted string constant' do
-    tree = JCR.parse( "$trule = type 'a string constant'" )
-    expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
-  end
-
-  it 'should parse a single quoted string constant' do
-    tree = JCR.parse( "$trule = :'a string constant'" )
-    expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
-  end
-
-  it 'should parse a single quoted string constant without leading colon' do
-    tree = JCR.parse( "$trule = 'a string constant'" )
-    expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:primitive_rule][:q_string]).to eq("a string constant")
-  end
-
   it 'should parse a string' do
     tree = JCR.parse( '$trule = type string' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
@@ -460,25 +442,19 @@ describe 'parser' do
   end
 
   it 'should parse an any member rule with integer value' do
-    tree = JCR.parse( '$trule = `.*` : integer' )
+    tree = JCR.parse( '$trule = /.*/ : integer' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq(".*")
     expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
-  it 'should parse an any member rule of `.*`' do
-    tree = JCR.parse( '$trule = `.*` : integer' )
+  it 'should parse an any member rule of /.*/' do
+    tree = JCR.parse( '$trule = /.*/ : integer' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq(".*")
-    expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
-  end
-
-  it 'should parse an any member rule of `` treated as `.*`' do
-    tree = JCR.parse( '$trule = `` : integer' )
-    expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq([])
     expect(tree[0][:rule][:member_rule][:primitive_rule][:integer_v]).to eq("integer")
   end
 
   it 'should parse an regex member rule with string value' do
-    tree = JCR.parse( '$trule = `a.regex\\.goes.here.*` : string' )
+    tree = JCR.parse( '$trule = /a.regex\\.goes.here.*/ : string' )
     expect(tree[0][:rule][:member_rule][:member_regex][:regex]).to eq("a.regex\\.goes.here.*")
     expect(tree[0][:rule][:member_rule][:primitive_rule][:string]).to eq("string")
   end
@@ -970,17 +946,17 @@ describe 'parser' do
   end
 
   it 'should parse a group rule with a member rule specified with a regex that has a value rule' do
-    tree = JCR.parse( '$trule = ( `.*` : integer )' )
+    tree = JCR.parse( '$trule = ( /.*/ : integer )' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse a group rule with a member rule specified with a regex and repetition that has a value rule' do
-    tree = JCR.parse( '$trule = ( `.*` : integer *0..15 )' )
+    tree = JCR.parse( '$trule = ( /.*/ : integer *0..15 )' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse a group rule with a member rule specified with a regex and only repetition min that has a value rule' do
-    tree = JCR.parse( '$trule = ( `.*` : integer * 1.. )' )
+    tree = JCR.parse( '$trule = ( /.*/ : integer * 1.. )' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
@@ -1040,18 +1016,18 @@ describe 'parser' do
   end
 
   it 'should parse a member regex rule with a comment' do
-    tree = JCR.parse( "$trule = `.*` : $target_rule ;\;;\n" )
+    tree = JCR.parse( "$trule = /.*/ : $target_rule ;\;;\n" )
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
   it 'should parse two rules on the same line' do
-    tree = JCR.parse( '$trule1 = :/.*/  $trule2 = `.*` : $target_rule' )
+    tree = JCR.parse( '$trule1 = :/.*/  $trule2 = /.*/ : $target_rule' )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
     expect(tree[1][:rule][:rule_name]).to eq("trule2")
   end
 
   it 'should parse two rules on the same line without : prefix' do
-    tree = JCR.parse( '$trule1 = /.*/  $trule2 = `.*` : $target_rule' )
+    tree = JCR.parse( '$trule1 = /.*/  $trule2 = /.*/ : $target_rule' )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
     expect(tree[1][:rule][:rule_name]).to eq("trule2")
   end
@@ -1107,7 +1083,7 @@ describe 'parser' do
 ;comment 3
 ;comment 4
 #jcr-version 4.0
-$trule2 =`.*` :$target_rule
+$trule2 =/.*/ :$target_rule
 EX
     tree = JCR.parse( ex )
     expect(tree[1][:rule][:rule_name]).to eq("trule2")
@@ -1120,7 +1096,7 @@ $trule1= type /.*/
 ;comment 2
 ;comment 3
 ;comment 4
-$trule2 =`.*` :$target_rule
+$trule2 =/.*/ :$target_rule
 EX
     tree = JCR.parse( ex )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
@@ -1134,7 +1110,7 @@ $trule1
 	;comment 2
 	=:
 /.*/
-$trule2 = `.*`: $target_rule
+$trule2 = /.*/: $target_rule
 EX
     tree = JCR.parse( ex )
     expect(tree[0][:rule][:rule_name]).to eq("trule1")
@@ -1538,7 +1514,7 @@ EX8
 
   it 'should parse ex4 from I-D' do
     ex9 = <<EX9
-$any_member = `.*` : any
+$any_member = /.*/ : any
 
 $object_of_anything =: { $any_member* }
 EX9
@@ -1548,7 +1524,7 @@ EX9
 
   it 'should parse ex5 from I-D' do
     ex10 = <<EX10
-$object_of_anything = :{ `.*`:any* }
+$object_of_anything = :{ /.*/:any* }
 EX10
     tree = JCR.parse( ex10 )
     expect(tree[0][:rule][:rule_name]).to eq("object_of_anything")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -893,28 +893,6 @@ describe 'parser' do
     expect(tree[0][:rule][:array_rule][:group_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
   end
 
-  it 'should parse an array rule with an explicit type choice' do
-    tree = JCR.parse( '$trule = :[ :($my_rule1| $my_rule2 )+]' )
-    expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:array_rule][:group_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
-    expect(tree[0][:rule][:array_rule][:group_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
-  end
-
-  it 'should parse an array rule with an explicit type choice' do
-    tree = JCR.parse( '$trule = :[ type ($my_rule1| $my_rule2 )+]' )
-    expect(tree[0][:rule][:rule_name]).to eq("trule")
-    expect(tree[0][:rule][:array_rule][:group_rule][0][:target_rule_name][:rule_name]).to eq("my_rule1")
-    expect(tree[0][:rule][:array_rule][:group_rule][1][:target_rule_name][:rule_name]).to eq("my_rule2")
-  end
-
-  it 'should NOT parse an array rule with an invalid explicit type choice' do
-    expect{ tree = JCR.parse( '$trule = :[ :($my_rule1, $my_rule2 )+]' ) }.to raise_error Parslet::ParseFailed
-  end
-
-  it 'should NOT parse an array rule with an invalid explicit type choice' do
-    expect{ tree = JCR.parse( '$trule = :[ type ($my_rule1, $my_rule2 )+]' ) }.to raise_error Parslet::ParseFailed
-  end
-
   it 'should parse an array rule with a rulename and a group rule' do
     tree = JCR.parse( '$trule = :[ $my_rule1 | ( integer | { $my_rule2 } ) ]' )
     expect(tree[0][:rule][:rule_name]).to eq("trule")


### PR DESCRIPTION
As discussed, this PR supports the following:

- Not require : before types (but optionally allow it for backwards compatibility)

- Remove the single quoted strings

- Remove backtick quoted regex names

- Remove explicit-type-choice

In removing the backtick regexes, I've anchored some of the test cases more explicitly than they were in earlier versions.