### PR TITLE
Exclude min max annotations

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -75,12 +75,15 @@ annotations      = *( "@{" *sp-cmt annotation-set *sp-cmt "}"
 annotation-set   = not-annotation / unordered-annotation /
                    root-annotation /
                    exclude-min-annotation / exclude-max-annotation /
-                   tbd-annotation
+                   default-annotation / tbd-annotation
 not-annotation   = not-kw
 unordered-annotation = unordered-kw
 root-annotation  = root-kw
 exclude-min-annotation = exclude-min-kw
 exclude-max-annotation = exclude-max-kw
+default-annotation = annotation-name spaces primitive-value
+primitive-value  = false-value / null-type / true-value /
+                   float-value / integer-value / string-value
 tbd-annotation   = annotation-name [ spaces annotation-parameters ]
 annotation-name  = name
 annotation-parameters = multi-line-parameters
@@ -231,6 +234,7 @@ base64url-kw     = %x62.61.73.65.36.34.75.72.6C    ; "base64url"
 boolean-kw       = %x62.6F.6F.6C.65.61.6E          ; "boolean"
 date-kw          = %x64.61.74.65                   ; "date"
 datetime-kw      = %x64.61.74.65.74.69.6D.65       ; "datetime"
+default-kw       = %x64.65.66.61.75.6C.74          ; "default"
 double-kw        = %x64.6F.75.62.6C.65             ; "double"
 email-kw         = %x65.6D.61.69.6C                ; "email"
 exclude-max-kw   = %x65.78.63.6C.75.64.65.2D.6D.61.78 ; "exclude-max"

--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -73,10 +73,14 @@ type-choice-items = *sp-cmt ( type-choice / type-rule ) *sp-cmt
 annotations      = *( "@{" *sp-cmt annotation-set *sp-cmt "}"
                    *sp-cmt )
 annotation-set   = not-annotation / unordered-annotation /
-                   root-annotation / tbd-annotation
+                   root-annotation /
+                   exclude-min-annotation / exclude-max-annotation /
+                   tbd-annotation
 not-annotation   = not-kw
 unordered-annotation = unordered-kw
 root-annotation  = root-kw
+exclude-min-annotation = exclude-min-kw
+exclude-max-annotation = exclude-max-kw
 tbd-annotation   = annotation-name [ spaces annotation-parameters ]
 annotation-name  = name
 annotation-parameters = multi-line-parameters
@@ -229,6 +233,8 @@ date-kw          = %x64.61.74.65                   ; "date"
 datetime-kw      = %x64.61.74.65.74.69.6D.65       ; "datetime"
 double-kw        = %x64.6F.75.62.6C.65             ; "double"
 email-kw         = %x65.6D.61.69.6C                ; "email"
+exclude-max-kw   = %x65.78.63.6C.75.64.65.2D.6D.61.78 ; "exclude-max"
+exclude-min-kw   = %x65.78.63.6C.75.64.65.2D.6D.69.6E ; "exclude-min"
 false-kw         = %x66.61.6C.73.65                ; "false"
 float-kw         = %x66.6C.6F.61.74                ; "float"
 fqdn-kw          = %x66.71.64.6E                   ; "fqdn"

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -156,9 +156,13 @@ module JCR
     rule(:annotations)       { ( str('@{') >> spcCmnt? >> annotation_set >> spcCmnt? >> str('}') >> spcCmnt? ).repeat }
         #! annotations = *( "@{" spcCmnt? annotation_set spcCmnt? "}"
         #!                  spcCmnt? )
-    rule(:annotation_set)    { not_annotation | unordered_annotation | root_annotation | tbd_annotation }
+    rule(:annotation_set)    { not_annotation | unordered_annotation | root_annotation |
+                               exclude_min_annotation | exclude_max_annotation |
+                               tbd_annotation }
         #! annotation_set = not_annotation / unordered_annotation /
-        #!                  root_annotation / tbd_annotation
+        #!                  root_annotation /
+        #!                  exclude_min_annotation / exclude_max_annotation /
+        #!                  tbd_annotation
     rule(:not_annotation) { str('not').as(:not_annotation) }
         #! not_annotation = not-kw
         #> not-kw = "not"
@@ -168,6 +172,12 @@ module JCR
     rule(:root_annotation)   { str('root').as(:root_annotation) }
         #! root_annotation = root-kw
         #> root-kw = "root"
+    rule(:exclude_min_annotation)   { str('exclude-min').as(:exclude_min_annotation) }
+        #! exclude_min_annotation = exclude-min-kw
+        #> exclude-min-kw = "exclude-min"
+    rule(:exclude_max_annotation)   { str('exclude-max').as(:exclude_max_annotation) }
+        #! exclude_max_annotation = exclude-max-kw
+        #> exclude-max-kw = "exclude-max"
     rule(:tbd_annotation)    { name.as(:annotation_name) >> ( spaces >> annotation_parameters.as(:annotation_parameters) ).maybe }
         #! tbd_annotation = annotation_name [ spaces annotation_parameters ]
         #! annotation_name = name

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -158,11 +158,11 @@ module JCR
         #!                  spcCmnt? )
     rule(:annotation_set)    { not_annotation | unordered_annotation | root_annotation |
                                exclude_min_annotation | exclude_max_annotation |
-                               tbd_annotation }
+                               default_annotation | tbd_annotation }
         #! annotation_set = not_annotation / unordered_annotation /
         #!                  root_annotation /
         #!                  exclude_min_annotation / exclude_max_annotation /
-        #!                  tbd_annotation
+        #!                  default_annotation / tbd_annotation
     rule(:not_annotation) { str('not').as(:not_annotation) }
         #! not_annotation = not-kw
         #> not-kw = "not"
@@ -178,6 +178,12 @@ module JCR
     rule(:exclude_max_annotation)   { str('exclude-max').as(:exclude_max_annotation) }
         #! exclude_max_annotation = exclude-max-kw
         #> exclude-max-kw = "exclude-max"
+    rule(:default_annotation)    { str('default').as(:default_annotation) >> spaces >> primitive_value }
+        #! default_annotation = annotation_name spaces primitive-value
+        #> default-kw = "default"
+    rule(:primitive_value) { false_value | null_type | true_value | float_value | integer_value | string_value }
+        #! primitive_value = false_value / null_type / true_value /
+        #!                   float_value / integer_value / string_value
     rule(:tbd_annotation)    { name.as(:annotation_name) >> ( spaces >> annotation_parameters.as(:annotation_parameters) ).maybe }
         #! tbd_annotation = annotation_name [ spaces annotation_parameters ]
         #! annotation_name = name

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1740,6 +1740,30 @@ EX12
     tree = JCR.parse( '$my_mem = "count" : @{exclude-max} 0..100' )
   end
 
+  it 'should parse member rule with {default null} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{default null} (null | boolean)' )
+  end
+
+  it 'should parse member rule with {default true} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{default true} boolean' )
+  end
+
+  it 'should parse member rule with {default false} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{default false} boolean' )
+  end
+
+  it 'should parse member rule with {default 123} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{default 123} integer' )
+  end
+
+  it 'should parse member rule with {default 123.2} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{default 123.2} float' )
+  end
+
+  it 'should parse member rule with {default "open"} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{default "open"} string' )
+  end
+
   it 'should parse an unknown annotation' do
     tree = JCR.parse( '$my_int =: @{assert $ % 3 == 0} 2' )
     expect(tree[0][:rule][:rule_name]).to eq("my_int")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1732,6 +1732,14 @@ EX12
     expect(tree[0][:rule][:rule_name]).to eq("trule")
   end
 
+  it 'should parse member rule with {exclude-min} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{exclude-min} 0..100' )
+  end
+
+  it 'should parse member rule with {exclude-max} annotation directive' do
+    tree = JCR.parse( '$my_mem = "count" : @{exclude-max} 0..100' )
+  end
+
   it 'should parse an unknown annotation' do
     tree = JCR.parse( '$my_int =: @{assert $ % 3 == 0} 2' )
     expect(tree[0][:rule][:rule_name]).to eq("my_int")


### PR DESCRIPTION
I've updated the parser and parser tests to support @{exclude-min}, @{exclude-max} and @{default ???}.

NOTE WELL!...

I haven't updated the validation side of things.  evaluate_value_rules.rb:53 and evaluate_value_rules.rb:94 look relevant, but I think you also do some rationalisation of specified annotations before the code gets to that stage (e.g. evaluate-rules.rb:223).  Rather than wade in and risk causing more trouble than good, I decided to leave that to you.