### PR TITLE
Don't give slash in annotations and multi-line directives special meaning

### DIFF
--- a/abnf/jcr-abnf.txt
+++ b/abnf/jcr-abnf.txt
@@ -41,10 +41,10 @@ eol              = CR / LF
 multi-line-tbd-directive-d = directive-name
                    [ 1*sp-cmt multi-line-directive-parameters ]
 multi-line-directive-parameters = multi-line-parameters
-multi-line-parameters = *(comment / q-string / regex /
+multi-line-parameters = *(comment / q-string /
                    not-multi-line-special)
-not-multi-line-special = spaces / %x21 / %x23-2E / %x30-3A /
-                   %x3C-7C / %x7E-10FFFF ; not ", /, ; or }
+not-multi-line-special = spaces / %x21 / %x23-3A /
+                   %x3C-7C / %x7E-10FFFF ; not ", ; or }
 
 root-rule        = value-rule / group-rule
 

--- a/lib/jcr/parser.rb
+++ b/lib/jcr/parser.rb
@@ -102,11 +102,11 @@ module JCR
         #!                   [ 1*spcCmnt multi_line_directive_parameters ]
     rule(:multi_line_directive_parameters) { multi_line_parameters }
         #! multi_line_directive_parameters = multi_line_parameters
-    rule(:multi_line_parameters) { (comment | q_string | regex | match('[^"/;}]')).repeat }
-        #! multi_line_parameters = *(comment / q_string / regex /
+    rule(:multi_line_parameters) { (comment | q_string | match('[^";}]')).repeat }
+        #! multi_line_parameters = *(comment / q_string /
         #!                         not_multi_line_special)
-        #! not_multi_line_special = spaces / %x21 / %x23-2E / %x30-3A /
-        #!                          %x3C-7C / %x7E-10FFFF ; not ", /, ; or }
+        #! not_multi_line_special = spaces / %x21 / %x23-3A /
+        #!                          %x3C-7C / %x7E-10FFFF ; not ", ; or }
         #!
 
     rule(:root_rule) { value_rule | group_rule } # N.B. Not target_rule_name

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1424,10 +1424,10 @@ EX5e
     expect(tree[0][:directive][:directive_name]).to eq("constraint")
   end
 
-  it 'should parse multi-line unknown directives with comment, q_strings and regexs' do
+  it 'should parse multi-line unknown directives with comment, q_strings and regex style functions' do
     ex5f = %q[
 #{constraint foo
-  $name == /p\d{1,5}/ && ; Must allow } and { in comments
+  $name == re("/p\d{1,5}/i") && ; Must allow } and { in comments
   $when == "} with {"
 }
 # ruleset-id my_awesome_rules
@@ -1742,8 +1742,8 @@ EX12
     expect(tree[0][:rule][:rule_name]).to eq("my_int")
   end
 
-  it 'should parse an unknown annotation with comments, q_string and regexs' do
-    tree = JCR.parse( '$my_int =: @{assert $name == /p\d{1,5}/ && ; Must allow } and { in comments
+  it 'should parse an unknown annotation with comments, q_string and regex style functions' do
+    tree = JCR.parse( '$my_int =: @{assert $name == re("/p\d{1,5}/") && ; Must allow } and { in comments
                           $when == "} with {"
                           } 2' )
     expect(tree[0][:rule][:rule_name]).to eq("my_int")


### PR DESCRIPTION
(e.g. don't treat / as start of regex)

Note that the ABNF in this branch doesn't include the @{exclude-min}, @{exclude-max}, @{default} annotations, so some merges will need to be done before yanking the ABNF into the new draft.